### PR TITLE
Improve API reliability and error handling

### DIFF
--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -14,6 +14,8 @@ from dataclasses import dataclass
 from typing import Optional, TYPE_CHECKING
 
 import requests
+from requests.adapters import HTTPAdapter
+from urllib3.util.retry import Retry
 
 if TYPE_CHECKING:
     from .storage import SecretStorage
@@ -107,6 +109,16 @@ class HondaAPI:
                  token_file: Optional[Path] = None):
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)
+        retry = Retry(
+            total=3,
+            backoff_factor=1,
+            status_forcelist=(500, 502, 503, 504),
+            allowed_methods=None,
+            raise_on_status=False,
+        )
+        adapter = HTTPAdapter(max_retries=retry)
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
         self._storage = storage
 
         # Backward compatibility: token_file without storage
@@ -203,7 +215,8 @@ class HondaAPI:
             f"/user/get-login-info?userid={uid}"
             f"&agreementType=1&country={country}&language={language}",
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
 
     def get_vehicles(self, **kwargs) -> list[dict]:
@@ -230,7 +243,8 @@ class HondaAPI:
         resp = self._request(
             "GET", f"/tsp/dashboard-latest?vin={vin}&languageCode={language}",
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
 
     def request_dashboard_refresh(self, vin: str) -> str:
@@ -300,6 +314,15 @@ class HondaAPI:
         status_url = data.get("statusQueryGetUri", "")
         return status_url.split("id=")[-1] if "id=" in status_url else ""
 
+    def _async_put_command(self, path: str, json_body: dict) -> str:
+        """Send an async PUT command, return the command ID."""
+        resp = self._request("PUT", path, json=json_body)
+        if resp.status_code not in (200, 202):
+            raise HondaAPIError(resp.status_code, resp.text)
+        data = resp.json()
+        status_url = data.get("statusQueryGetUri", "")
+        return status_url.split("id=")[-1] if "id=" in status_url else ""
+
     def remote_lock(self, vin: str) -> str:
         """Lock all doors."""
         return self._remote_command("remote-lock", vin, command="allLock")
@@ -360,27 +383,10 @@ class HondaAPI:
         valid = (80, 85, 90, 95, 100)
         if home not in valid or away not in valid:
             raise ValueError(f"Charge limits must be one of {valid}")
-        self._ensure_auth()
-        headers = {
-            "authorization": f"Bearer {self.tokens.access_token}",
-        }
-        if self.tokens.personal_id:
-            headers["x-app-personal-id"] = self.tokens.personal_id
-
-        resp = self.session.put(
-            f"{API_BASE}/tsp/maximum-charge-config",
-            headers=headers,
-            json={
-                "vin": vin,
-                "locationHome": {"maxCharge": home},
-                "locationAway": {"maxCharge": away},
-            },
+        return self._async_put_command(
+            "/tsp/maximum-charge-config",
+            {"vin": vin, "locationHome": {"maxCharge": home}, "locationAway": {"maxCharge": away}},
         )
-        if resp.status_code not in (200, 202):
-            raise HondaAPIError(resp.status_code, resp.text)
-        data = resp.json()
-        status_url = data.get("statusQueryGetUri", "")
-        return status_url.split("id=")[-1] if "id=" in status_url else ""
 
     def get_charge_schedule(self, vin: str, fresh: bool = False) -> list[dict]:
         """Get charge prohibition schedule from dashboard.
@@ -415,13 +421,6 @@ class HondaAPI:
         Returns:
             Async command ID for polling.
         """
-        self._ensure_auth()
-        headers = {
-            "authorization": f"Bearer {self.tokens.access_token}",
-        }
-        if self.tokens.personal_id:
-            headers["x-app-personal-id"] = self.tokens.personal_id
-
         settings = []
         for i in range(2):
             if i < len(rules) and rules[i].get("enabled", True):
@@ -451,16 +450,10 @@ class HondaAPI:
                     },
                 })
 
-        resp = self.session.put(
-            f"{API_BASE}/tsp/charge-prohibition-schedule",
-            headers=headers,
-            json={"vin": vin, "chargeProhibitionTimerSettings": settings},
+        return self._async_put_command(
+            "/tsp/charge-prohibition-schedule",
+            {"vin": vin, "chargeProhibitionTimerSettings": settings},
         )
-        if resp.status_code not in (200, 202):
-            raise HondaAPIError(resp.status_code, resp.text)
-        data = resp.json()
-        status_url = data.get("statusQueryGetUri", "")
-        return status_url.split("id=")[-1] if "id=" in status_url else ""
 
     def get_climate_schedule(self, vin: str, fresh: bool = False) -> list[dict]:
         """Get climate schedule from dashboard.
@@ -491,13 +484,6 @@ class HondaAPI:
         Returns:
             Async command ID for polling.
         """
-        self._ensure_auth()
-        headers = {
-            "authorization": f"Bearer {self.tokens.access_token}",
-        }
-        if self.tokens.personal_id:
-            headers["x-app-personal-id"] = self.tokens.personal_id
-
         settings = []
         for i in range(7):
             if i < len(rules) and rules[i].get("enabled", True):
@@ -518,21 +504,16 @@ class HondaAPI:
                     "acTimerOption": {"acStartTime1": "0000"},
                 })
 
-        resp = self.session.put(
-            f"{API_BASE}/tsp/remote-climate-schedule",
-            headers=headers,
-            json={"vin": vin, "acTimerSettings": settings},
+        return self._async_put_command(
+            "/tsp/remote-climate-schedule",
+            {"vin": vin, "acTimerSettings": settings},
         )
-        if resp.status_code not in (200, 202):
-            raise HondaAPIError(resp.status_code, resp.text)
-        data = resp.json()
-        status_url = data.get("statusQueryGetUri", "")
-        return status_url.split("id=")[-1] if "id=" in status_url else ""
 
     def get_drivers(self, vin: str) -> dict:
         """Get drivers associated with the vehicle."""
         resp = self._request("GET", f"/tsp/drivers-by-vehicle?vin={vin}")
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
 
     def get_trips(self, vin: str, month_start: str = "", page: int = 1) -> dict:
@@ -555,7 +536,8 @@ class HondaAPI:
             "GET",
             f"/tsp/journey-history?vin={vin}&monthStart={encoded_month}&page={page}",
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
 
     def get_trip_detail(self, vin: str, from_date: str, to_date: str,
@@ -576,7 +558,8 @@ class HondaAPI:
             f"/tsp/journey-history-detail?vin={vin}"
             f"&fromDate={enc_from}&toDate={enc_to}&type={trip_type}",
         )
-        resp.raise_for_status()
+        if resp.status_code != 200:
+            raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
     def get_all_trips(self, vin: str, month_start: str = "",
                        ref_date: str = "") -> list[dict]:

--- a/src/pymyhondaplus/auth.py
+++ b/src/pymyhondaplus/auth.py
@@ -273,7 +273,7 @@ class HondaAuth:
             "applicationVersion": "3.0.0",
         })
         resp = self._post("/auth/initiate-login", json_data=payload)
-        logger.info("initiate-login: %s %s", resp.status_code, resp.text[:300] if resp.text else "")
+        logger.info("initiate-login: %s", resp.status_code)
         if resp.status_code not in (200, 202):
             raise RuntimeError(f"initiate-login failed: {resp.status_code} {resp.text}")
         return resp.json()
@@ -295,7 +295,7 @@ class HondaAuth:
             "signedChallengeResponse": signed_challenge,
         })
         resp = self._post("/auth/complete-login", json_data=payload)
-        logger.info("complete-login: %s %s", resp.status_code, resp.text[:300] if resp.text else "")
+        logger.info("complete-login: %s", resp.status_code)
         if resp.status_code not in (200, 202):
             raise RuntimeError(f"complete-login failed: {resp.status_code} {resp.text}")
         return resp.json()
@@ -314,7 +314,7 @@ class HondaAuth:
         encoded_key = urllib.parse.quote(key, safe="+/=")
         url = f"{API_BASE}/auth/verify-link?type={link_type}&key={encoded_key}&dontRedirect=true"
         resp = self.session.get(url)
-        logger.info("verify-link GET: %s %s", resp.status_code, resp.text[:200] if resp.text else "")
+        logger.info("verify-link GET: %s", resp.status_code)
         return {"status_code": resp.status_code, "body": resp.text}
 
     def full_login(self, email: str, password: str, locale: str = "it") -> dict:

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -10,8 +10,6 @@ import time
 from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
-import requests
-
 from .api import DEFAULT_TOKEN_FILE, HondaAPI, HondaAPIError, compute_trip_stats, parse_ev_status
 from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth
 from .storage import get_storage
@@ -475,7 +473,7 @@ vehicle selection (only needed with multiple vehicles):
                 api.set_charge_schedule(vin, rules),
                 f"Charge schedule rule {args.rule}",
             )
-        except (requests.HTTPError, HondaAPIError):
+        except HondaAPIError:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Charge schedule is not available for {role} users.")
@@ -488,7 +486,7 @@ vehicle selection (only needed with multiple vehicles):
                 api.set_charge_schedule(vin, []),
                 "Clear charge schedule",
             )
-        except (requests.HTTPError, HondaAPIError):
+        except HondaAPIError:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Charge schedule is not available for {role} users.")
@@ -529,7 +527,7 @@ vehicle selection (only needed with multiple vehicles):
                 api.set_climate_schedule(vin, rules),
                 f"Climate schedule slot {args.slot}",
             )
-        except (requests.HTTPError, HondaAPIError):
+        except HondaAPIError:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Climate schedule is not available for {role} users.")
@@ -542,7 +540,7 @@ vehicle selection (only needed with multiple vehicles):
                 api.set_climate_schedule(vin, []),
                 "Clear climate schedule",
             )
-        except (requests.HTTPError, HondaAPIError):
+        except HondaAPIError:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Climate schedule is not available for {role} users.")
@@ -563,12 +561,12 @@ vehicle selection (only needed with multiple vehicles):
                 rows = [dict(zip(fields, trip)) for trip in payload.get("data", [])]
                 if not args.json:
                     print(f"Page {data.get('page', '?')}/{data.get('maxPage', '?')}")
-        except requests.HTTPError as e:
+        except HondaAPIError as e:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Trip history is not available for {role} users.")
             else:
-                print(f"Failed to fetch trips: {e.response.status_code} {e.response.reason}")
+                print(f"Failed to fetch trips: {e}")
             return
 
         if not rows:
@@ -581,7 +579,7 @@ vehicle selection (only needed with multiple vehicles):
                 if args.locations and start != "?" and end != "?":
                     try:
                         row.update(api.get_trip_locations(vin, start, end))
-                    except requests.HTTPError:
+                    except HondaAPIError:
                         pass
                 if args.json:
                     json_rows.append(row)
@@ -600,8 +598,8 @@ vehicle selection (only needed with multiple vehicles):
     elif args.command == "trip-detail":
         try:
             locs = api.get_trip_locations(vin, args.start_time, args.end_time)
-        except requests.HTTPError as e:
-            print(f"Failed to fetch trip detail: {e.response.status_code} {e.response.reason}")
+        except HondaAPIError as e:
+            print(f"Failed to fetch trip detail: {e}")
             return
         if args.json:
             print(json.dumps(locs, indent=2))
@@ -632,12 +630,12 @@ vehicle selection (only needed with multiple vehicles):
 
         try:
             all_rows = api.get_all_trips(vin, month_start=month_start)
-        except requests.HTTPError as e:
+        except HondaAPIError as e:
             role = (vehicle_info or {}).get("role", "")
             if role and role != "primary":
                 print(f"Trip history is not available for {role} users.")
             else:
-                print(f"Failed to fetch trips: {e.response.status_code} {e.response.reason}")
+                print(f"Failed to fetch trips: {e}")
             return
 
         # Filter to period

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,0 +1,193 @@
+"""Tests for HondaAPI HTTP layer — auth headers, token refresh, error handling."""
+
+from unittest.mock import MagicMock, patch, call
+import time
+
+import pytest
+import requests
+
+from pymyhondaplus.api import HondaAPI, HondaAPIError, AuthTokens
+
+
+def _make_api(**token_overrides):
+    """Create a HondaAPI instance with fake tokens and no storage."""
+    api = HondaAPI()
+    defaults = dict(
+        access_token="tok123",
+        refresh_token="ref456",
+        expires_at=time.time() + 3600,
+        personal_id="pid789",
+        user_id="uid",
+    )
+    defaults.update(token_overrides)
+    api.tokens = AuthTokens(**defaults)
+    return api
+
+
+def _mock_response(status_code=200, json_data=None, text=""):
+    resp = MagicMock(spec=requests.Response)
+    resp.status_code = status_code
+    resp.json.return_value = json_data or {}
+    resp.text = text or ""
+    resp.raise_for_status = MagicMock()
+    if status_code >= 400:
+        resp.raise_for_status.side_effect = requests.HTTPError(response=resp)
+    return resp
+
+
+class TestRequestAuth:
+    """_request() sets correct auth headers and handles 401 retry."""
+
+    def test_sets_bearer_and_personal_id(self):
+        api = _make_api()
+        resp = _mock_response(200, {"ok": True})
+        api.session.request = MagicMock(return_value=resp)
+
+        api._request("GET", "/test")
+
+        _, kwargs = api.session.request.call_args
+        assert kwargs["headers"]["authorization"] == "Bearer tok123"
+        assert kwargs["headers"]["x-app-personal-id"] == "pid789"
+
+    def test_sets_bearer_without_personal_id(self):
+        api = _make_api(personal_id="")
+        resp = _mock_response(200)
+        api.session.request = MagicMock(return_value=resp)
+
+        api._request("GET", "/test")
+
+        _, kwargs = api.session.request.call_args
+        assert kwargs["headers"]["authorization"] == "Bearer tok123"
+        assert "x-app-personal-id" not in kwargs["headers"]
+
+    def test_retries_on_401_with_token_refresh(self):
+        api = _make_api()
+        resp_401 = _mock_response(401)
+        resp_ok = _mock_response(200, {"data": "fresh"})
+        api.session.request = MagicMock(side_effect=[resp_401, resp_ok])
+
+        # Mock refresh_auth to update the token
+        def fake_refresh():
+            api.tokens.access_token = "newtok"
+            return api.tokens
+        api.refresh_auth = fake_refresh
+
+        result = api._request("GET", "/test")
+
+        assert result == resp_ok
+        assert api.session.request.call_count == 2
+        # Second call should use refreshed token
+        _, kwargs2 = api.session.request.call_args_list[1]
+        assert kwargs2["headers"]["authorization"] == "Bearer newtok"
+
+    def test_raises_without_tokens(self):
+        api = _make_api(access_token="")
+        with pytest.raises(HondaAPIError, match="No tokens configured"):
+            api._request("GET", "/test")
+
+
+class TestPutMethods:
+    """PUT methods send correct payloads and return command IDs."""
+
+    def _setup_put(self, api):
+        """Set up session mock for PUT methods."""
+        resp = _mock_response(202, {
+            "statusQueryGetUri": "https://example.com/status?id=cmd-abc-123"
+        })
+        api.session.put = MagicMock(return_value=resp)
+        # Also mock session.request for methods that go through _request
+        api.session.request = MagicMock(return_value=resp)
+        return resp
+
+    def test_set_charge_limit_payload(self):
+        api = _make_api()
+        self._setup_put(api)
+
+        result = api.set_charge_limit("VIN123", home=85, away=95)
+
+        assert result == "cmd-abc-123"
+        # Verify the PUT was called (either directly or via _request)
+        put_call = api.session.put if api.session.put.called else None
+        req_call = api.session.request if api.session.request.called else None
+        called = put_call or req_call
+        assert called is not None
+
+    def test_set_charge_limit_invalid(self):
+        api = _make_api()
+        with pytest.raises(ValueError, match="Charge limits must be one of"):
+            api.set_charge_limit("VIN123", home=77, away=90)
+
+    def test_set_charge_schedule_payload(self):
+        api = _make_api()
+        self._setup_put(api)
+
+        rules = [{"days": "mon,tue", "location": "all",
+                  "start_time": "07:00", "end_time": "08:00"}]
+        result = api.set_charge_schedule("VIN123", rules)
+
+        assert result == "cmd-abc-123"
+
+    def test_set_climate_schedule_payload(self):
+        api = _make_api()
+        self._setup_put(api)
+
+        rules = [{"days": "mon,fri", "start_time": "07:00"}]
+        result = api.set_climate_schedule("VIN123", rules)
+
+        assert result == "cmd-abc-123"
+
+    def test_put_methods_use_request_for_401_retry(self):
+        """PUT methods go through _request() and get automatic 401 retry."""
+        api = _make_api()
+        resp_401 = _mock_response(401)
+        resp_ok = _mock_response(202, {
+            "statusQueryGetUri": "https://example.com/status?id=retried-ok"
+        })
+        api.session.request = MagicMock(side_effect=[resp_401, resp_ok])
+
+        def fake_refresh():
+            api.tokens.access_token = "refreshed"
+            return api.tokens
+        api.refresh_auth = fake_refresh
+
+        result = api.set_charge_limit("VIN123", home=80, away=90)
+
+        assert result == "retried-ok"
+        assert api.session.request.call_count == 2
+
+
+class TestErrorTypes:
+    """All API methods raise HondaAPIError on HTTP errors."""
+
+    def test_get_user_info_raises_honda_error_on_failure(self):
+        api = _make_api()
+        resp = _mock_response(500, text="Internal Server Error")
+        api.session.request = MagicMock(return_value=resp)
+
+        with pytest.raises(HondaAPIError):
+            api.get_user_info()
+
+    def test_get_trips_raises_honda_error_on_failure(self):
+        api = _make_api()
+        resp = _mock_response(403, text="Forbidden")
+        api.session.request = MagicMock(return_value=resp)
+
+        with pytest.raises(HondaAPIError):
+            api.get_trips("VIN123", month_start="2026-03-01T00:00:00.000Z")
+
+    def test_remote_command_raises_honda_error(self):
+        api = _make_api()
+        resp = _mock_response(500, text="Server Error")
+        api.session.request = MagicMock(return_value=resp)
+
+        with pytest.raises(HondaAPIError):
+            api.remote_lock("VIN123")
+
+    def test_set_charge_limit_raises_honda_error_on_failure(self):
+        api = _make_api()
+        resp = _mock_response(400, text="Bad Request")
+        api.session.put = MagicMock(return_value=resp)
+        api.session.request = MagicMock(return_value=resp)
+
+        with pytest.raises(HondaAPIError):
+            api.set_charge_limit("VIN123", home=80, away=90)


### PR DESCRIPTION
## Summary

- **Fix token refresh on PUT methods**: `set_charge_limit`, `set_charge_schedule`, and `set_climate_schedule` bypassed `_request()` and missed automatic 401 → token refresh → retry. Now routed through a shared `_async_put_command` helper.
- **Standardize errors on `HondaAPIError`**: Replaced all `raise_for_status()` calls (which raised `requests.HTTPError`) with `HondaAPIError`. Consumers now only need to catch one exception type.
- **Add retry for transient failures**: Mounted `urllib3.Retry` adapter on the session — auto-retries on 500/502/503/504 and connection errors with backoff.
- **Stop logging response bodies in auth flow**: Auth endpoints may return tokens; now only status codes are logged.

### Breaking change

API methods no longer raise `requests.HTTPError`. Consumers catching it should switch to `HondaAPIError`.

## Test plan

- [x] All 47 tests pass (`pytest tests/ -v`)
- [x] Manual verification: mangled access token, confirmed all three PUT methods recover via 401 retry
- [x] Smoke tested `charge-limit`, `charge-schedule-set`, `climate-schedule-set` against real API

🤖 Generated with [Claude Code](https://claude.com/claude-code)