### PR TITLE
Add 10-second HTTP timeout to all network requests

### DIFF
--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -571,7 +571,11 @@ class HondaAPI:
         self.session.headers.update(DEFAULT_HEADERS)
         self._lock = threading.Lock()
         retry = Retry(
-            total=3,
+            total=None,
+            status=3,
+            connect=0,
+            read=0,
+            other=0,
             backoff_factor=1,
             status_forcelist=(500, 502, 503, 504),
             allowed_methods=None,

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -14,23 +14,9 @@ from dataclasses import dataclass, field
 from typing import Optional, TYPE_CHECKING
 
 import requests
-from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-DEFAULT_TIMEOUT = 10
-
-
-class _TimeoutAdapter(HTTPAdapter):
-    """HTTPAdapter with a default timeout for all requests."""
-
-    def __init__(self, *args, timeout=DEFAULT_TIMEOUT, **kwargs):
-        self._timeout = timeout
-        super().__init__(*args, **kwargs)
-
-    def send(self, *args, **kwargs):
-        if kwargs.get("timeout") is None:
-            kwargs["timeout"] = self._timeout
-        return super().send(*args, **kwargs)
+from .http import DEFAULT_REQUEST_TIMEOUT, TimeoutAdapter
 
 if TYPE_CHECKING:
     from .storage import SecretStorage
@@ -563,13 +549,16 @@ class HondaAPI:
     Args:
         storage: SecretStorage backend for token persistence. None disables persistence.
         token_file: Deprecated — use storage instead. Kept for backward compatibility.
+        request_timeout: Default timeout in seconds for HTTP requests.
     """
 
     def __init__(self, storage: Optional["SecretStorage"] = None,
-                 token_file: Optional[Path] = None):
+                 token_file: Optional[Path] = None,
+                 request_timeout: float = DEFAULT_REQUEST_TIMEOUT):
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)
         self._lock = threading.Lock()
+        self.request_timeout = request_timeout
         retry = Retry(
             total=None,
             status=3,
@@ -581,7 +570,7 @@ class HondaAPI:
             allowed_methods=None,
             raise_on_status=False,
         )
-        adapter = _TimeoutAdapter(max_retries=retry)
+        adapter = TimeoutAdapter(timeout=request_timeout, max_retries=retry)
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
         self._storage = storage

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -17,7 +17,7 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
-DEFAULT_TIMEOUT = 30
+DEFAULT_TIMEOUT = 10
 
 
 class _TimeoutAdapter(HTTPAdapter):

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -28,7 +28,8 @@ class _TimeoutAdapter(HTTPAdapter):
         super().__init__(*args, **kwargs)
 
     def send(self, *args, **kwargs):
-        kwargs.setdefault("timeout", self._timeout)
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = self._timeout
         return super().send(*args, **kwargs)
 
 if TYPE_CHECKING:

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -17,6 +17,20 @@ import requests
 from requests.adapters import HTTPAdapter
 from urllib3.util.retry import Retry
 
+DEFAULT_TIMEOUT = 30
+
+
+class _TimeoutAdapter(HTTPAdapter):
+    """HTTPAdapter with a default timeout for all requests."""
+
+    def __init__(self, *args, timeout=DEFAULT_TIMEOUT, **kwargs):
+        self._timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        kwargs.setdefault("timeout", self._timeout)
+        return super().send(*args, **kwargs)
+
 if TYPE_CHECKING:
     from .storage import SecretStorage
 
@@ -562,7 +576,7 @@ class HondaAPI:
             allowed_methods=None,
             raise_on_status=False,
         )
-        adapter = HTTPAdapter(max_retries=retry)
+        adapter = _TimeoutAdapter(max_retries=retry)
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
         self._storage = storage

--- a/src/pymyhondaplus/auth.py
+++ b/src/pymyhondaplus/auth.py
@@ -197,8 +197,12 @@ class HondaAuth:
     """Handles the full Honda Connect Europe authentication flow."""
 
     def __init__(self, device_key: Optional[DeviceKey] = None):
+        from .api import _TimeoutAdapter
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)
+        adapter = _TimeoutAdapter()
+        self.session.mount("https://", adapter)
+        self.session.mount("http://", adapter)
         self.device_key = device_key or DeviceKey()
 
     def _post(self, path: str, json_data: dict | None = None, **kwargs) -> requests.Response:

--- a/src/pymyhondaplus/auth.py
+++ b/src/pymyhondaplus/auth.py
@@ -15,6 +15,7 @@ from typing import Optional
 import requests
 
 from .api import HondaAuthError
+from .http import DEFAULT_REQUEST_TIMEOUT, TimeoutAdapter
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
@@ -196,11 +197,12 @@ class DeviceKey:
 class HondaAuth:
     """Handles the full Honda Connect Europe authentication flow."""
 
-    def __init__(self, device_key: Optional[DeviceKey] = None):
-        from .api import _TimeoutAdapter
+    def __init__(self, device_key: Optional[DeviceKey] = None,
+                 request_timeout: float = DEFAULT_REQUEST_TIMEOUT):
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)
-        adapter = _TimeoutAdapter()
+        self.request_timeout = request_timeout
+        adapter = TimeoutAdapter(timeout=request_timeout)
         self.session.mount("https://", adapter)
         self.session.mount("http://", adapter)
         self.device_key = device_key or DeviceKey()

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -21,6 +21,7 @@ except ImportError:
 
 from .api import DEFAULT_TOKEN_FILE, HondaAPI, HondaAPIError, HondaAuthError, compute_trip_stats, parse_ev_status
 from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth
+from .http import DEFAULT_REQUEST_TIMEOUT
 from .storage import get_storage
 from .translations import (
     CHARGE_MODE_FALLBACK_MAP, CHARGE_MODE_MAP, CHARGE_STATUS_MAP,
@@ -755,6 +756,12 @@ vehicle selection (only needed with multiple vehicles):
                          help="Show full tracebacks on error")
     _common.add_argument("--timeout", type=int, default=60,
                          help="Timeout in seconds for remote commands (default: 60)")
+    _common.add_argument(
+        "--http-timeout",
+        type=float,
+        default=DEFAULT_REQUEST_TIMEOUT,
+        help=f"Timeout in seconds for each HTTP request (default: {DEFAULT_REQUEST_TIMEOUT:g})",
+    )
 
     subparsers = parser.add_subparsers(dest="command")
 
@@ -883,7 +890,7 @@ def _run_main(args: argparse.Namespace, storage) -> int:
     """Run the CLI command flow and return an exit code."""
     if args.command == "login":
         device_key = DeviceKey(storage=storage)
-        auth = HondaAuth(device_key=device_key)
+        auth = HondaAuth(device_key=device_key, request_timeout=args.http_timeout)
         password = args.password or getpass.getpass("Password: ")
         try:
             result = auth.full_login(args.email, password, locale=args.locale)
@@ -895,7 +902,7 @@ def _run_main(args: argparse.Namespace, storage) -> int:
         print(f"Expires in: {result.get('expires_in', 'N/A')}s")
 
         user_id = HondaAuth.extract_user_id(result["access_token"])
-        api = HondaAPI(storage=storage)
+        api = HondaAPI(storage=storage, request_timeout=args.http_timeout)
         api.set_tokens(
             access_token=result["access_token"],
             refresh_token=result["refresh_token"],
@@ -925,7 +932,7 @@ def _run_main(args: argparse.Namespace, storage) -> int:
             print("Nothing to remove (not logged in)")
         return 0
 
-    api = HondaAPI(storage=storage)
+    api = HondaAPI(storage=storage, request_timeout=args.http_timeout)
 
     if args.user_info:
         info = api.get_user_info()

--- a/src/pymyhondaplus/http.py
+++ b/src/pymyhondaplus/http.py
@@ -1,0 +1,20 @@
+"""Shared HTTP transport utilities for pymyhondaplus."""
+
+import os
+
+from requests.adapters import HTTPAdapter
+
+DEFAULT_REQUEST_TIMEOUT = float(os.environ.get("HONDA_REQUEST_TIMEOUT", "10"))
+
+
+class TimeoutAdapter(HTTPAdapter):
+    """HTTPAdapter with a default timeout for all requests."""
+
+    def __init__(self, *args, timeout=DEFAULT_REQUEST_TIMEOUT, **kwargs):
+        self._timeout = timeout
+        super().__init__(*args, **kwargs)
+
+    def send(self, *args, **kwargs):
+        if kwargs.get("timeout") is None:
+            kwargs["timeout"] = self._timeout
+        return super().send(*args, **kwargs)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -197,7 +197,7 @@ class TestTimeoutAdapter:
     """_TimeoutAdapter applies default timeout to all requests."""
 
     def test_applies_default_timeout(self):
-        from pymyhondaplus.api import _TimeoutAdapter
+        from pymyhondaplus.api import _TimeoutAdapter, DEFAULT_TIMEOUT
         adapter = _TimeoutAdapter()
         kwargs = {"timeout": None}
         # Patch super().send to capture kwargs
@@ -205,7 +205,7 @@ class TestTimeoutAdapter:
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
             adapter.send("request", **kwargs)
             _, call_kwargs = mock_send.call_args
-            assert call_kwargs["timeout"] == 30
+            assert call_kwargs["timeout"] == DEFAULT_TIMEOUT
 
     def test_respects_explicit_timeout(self):
         from pymyhondaplus.api import _TimeoutAdapter

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -216,3 +216,35 @@ class TestTimeoutAdapter:
             adapter.send("request", **kwargs)
             _, call_kwargs = mock_send.call_args
             assert call_kwargs["timeout"] == 10
+
+    def test_hanging_server_times_out(self):
+        """Real connection to a black-hole socket times out instead of hanging."""
+        import socket
+        import threading
+        from pymyhondaplus.api import _TimeoutAdapter
+
+        # Start a server that accepts but never responds
+        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
+        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        srv.bind(("127.0.0.1", 0))
+        srv.listen(1)
+        port = srv.getsockname()[1]
+
+        def accept_and_hold():
+            conn, _ = srv.accept()
+            # Hold the connection open until test finishes
+            conn.recv(4096)
+            conn.close()
+
+        t = threading.Thread(target=accept_and_hold, daemon=True)
+        t.start()
+
+        try:
+            session = requests.Session()
+            adapter = _TimeoutAdapter(timeout=1)
+            session.mount("http://", adapter)
+
+            with pytest.raises(requests.ConnectionError):
+                session.get(f"http://127.0.0.1:{port}/")
+        finally:
+            srv.close()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -191,3 +191,28 @@ class TestErrorTypes:
 
         with pytest.raises(HondaAPIError):
             api.set_charge_limit("VIN123", home=80, away=90)
+
+
+class TestTimeoutAdapter:
+    """_TimeoutAdapter applies default timeout to all requests."""
+
+    def test_applies_default_timeout(self):
+        from pymyhondaplus.api import _TimeoutAdapter
+        adapter = _TimeoutAdapter()
+        kwargs = {"timeout": None}
+        # Patch super().send to capture kwargs
+        from unittest.mock import patch
+        with patch("requests.adapters.HTTPAdapter.send") as mock_send:
+            adapter.send("request", **kwargs)
+            _, call_kwargs = mock_send.call_args
+            assert call_kwargs["timeout"] == 30
+
+    def test_respects_explicit_timeout(self):
+        from pymyhondaplus.api import _TimeoutAdapter
+        adapter = _TimeoutAdapter()
+        kwargs = {"timeout": 10}
+        from unittest.mock import patch
+        with patch("requests.adapters.HTTPAdapter.send") as mock_send:
+            adapter.send("request", **kwargs)
+            _, call_kwargs = mock_send.call_args
+            assert call_kwargs["timeout"] == 10

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -230,10 +230,12 @@ class TestTimeoutAdapter:
         srv.listen(1)
         port = srv.getsockname()[1]
 
+        stop = threading.Event()
+
         def accept_and_hold():
             conn, _ = srv.accept()
-            # Hold the connection open until test finishes
-            conn.recv(4096)
+            # Hold the connection open, never respond
+            stop.wait()
             conn.close()
 
         t = threading.Thread(target=accept_and_hold, daemon=True)
@@ -244,7 +246,8 @@ class TestTimeoutAdapter:
             adapter = _TimeoutAdapter(timeout=1)
             session.mount("http://", adapter)
 
-            with pytest.raises(requests.ConnectionError):
+            with pytest.raises(requests.exceptions.ReadTimeout):
                 session.get(f"http://127.0.0.1:{port}/")
         finally:
+            stop.set()
             srv.close()

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -221,3 +221,19 @@ class TestTimeoutAdapter:
             adapter.send(request, timeout=10)
             _, call_kwargs = mock_send.call_args
             assert call_kwargs["timeout"] == 10
+
+
+class TestRetryPolicy:
+    """HondaAPI retries only configured HTTP status responses."""
+
+    def test_retries_status_responses_but_not_transport_errors(self):
+        api = HondaAPI()
+        adapter = api.session.get_adapter("https://example.com")
+        retry = adapter.max_retries
+
+        assert retry.total is None
+        assert retry.status == 3
+        assert retry.connect == 0
+        assert retry.read == 0
+        assert retry.other == 0
+        assert retry.status_forcelist == (500, 502, 503, 504)

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -194,33 +194,40 @@ class TestErrorTypes:
 
 
 class TestTimeoutAdapter:
-    """_TimeoutAdapter applies default timeout to all requests."""
+    """TimeoutAdapter applies default timeout to all requests."""
 
     def test_applies_default_timeout(self):
-        from pymyhondaplus.api import _TimeoutAdapter, DEFAULT_TIMEOUT
+        from pymyhondaplus.http import DEFAULT_REQUEST_TIMEOUT, TimeoutAdapter
         from requests import PreparedRequest
         from unittest.mock import patch
 
-        adapter = _TimeoutAdapter()
+        adapter = TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
             request = PreparedRequest()
             request.prepare(method="GET", url="https://example.com")
             adapter.send(request)
             _, call_kwargs = mock_send.call_args
-            assert call_kwargs["timeout"] == DEFAULT_TIMEOUT
+            assert call_kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
 
     def test_respects_explicit_timeout(self):
-        from pymyhondaplus.api import _TimeoutAdapter
+        from pymyhondaplus.http import TimeoutAdapter
         from requests import PreparedRequest
         from unittest.mock import patch
 
-        adapter = _TimeoutAdapter()
+        adapter = TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
             request = PreparedRequest()
             request.prepare(method="GET", url="https://example.com")
             adapter.send(request, timeout=10)
             _, call_kwargs = mock_send.call_args
             assert call_kwargs["timeout"] == 10
+
+    def test_honda_api_uses_configured_timeout(self):
+        api = HondaAPI(request_timeout=3.5)
+        adapter = api.session.get_adapter("https://example.com")
+
+        assert api.request_timeout == 3.5
+        assert adapter._timeout == 3.5
 
 
 class TestRetryPolicy:

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -198,56 +198,26 @@ class TestTimeoutAdapter:
 
     def test_applies_default_timeout(self):
         from pymyhondaplus.api import _TimeoutAdapter, DEFAULT_TIMEOUT
-        adapter = _TimeoutAdapter()
-        kwargs = {"timeout": None}
-        # Patch super().send to capture kwargs
+        from requests import PreparedRequest
         from unittest.mock import patch
+
+        adapter = _TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
-            adapter.send("request", **kwargs)
+            request = PreparedRequest()
+            request.prepare(method="GET", url="https://example.com")
+            adapter.send(request)
             _, call_kwargs = mock_send.call_args
             assert call_kwargs["timeout"] == DEFAULT_TIMEOUT
 
     def test_respects_explicit_timeout(self):
         from pymyhondaplus.api import _TimeoutAdapter
-        adapter = _TimeoutAdapter()
-        kwargs = {"timeout": 10}
+        from requests import PreparedRequest
         from unittest.mock import patch
+
+        adapter = _TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
-            adapter.send("request", **kwargs)
+            request = PreparedRequest()
+            request.prepare(method="GET", url="https://example.com")
+            adapter.send(request, timeout=10)
             _, call_kwargs = mock_send.call_args
             assert call_kwargs["timeout"] == 10
-
-    def test_hanging_server_times_out(self):
-        """Real connection to a black-hole socket times out instead of hanging."""
-        import socket
-        import threading
-        from pymyhondaplus.api import _TimeoutAdapter
-
-        # Start a server that accepts but never responds
-        srv = socket.socket(socket.AF_INET, socket.SOCK_STREAM)
-        srv.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
-        srv.bind(("127.0.0.1", 0))
-        srv.listen(1)
-        port = srv.getsockname()[1]
-
-        stop = threading.Event()
-
-        def accept_and_hold():
-            conn, _ = srv.accept()
-            # Hold the connection open, never respond
-            stop.wait()
-            conn.close()
-
-        t = threading.Thread(target=accept_and_hold, daemon=True)
-        t.start()
-
-        try:
-            session = requests.Session()
-            adapter = _TimeoutAdapter(timeout=1)
-            session.mount("http://", adapter)
-
-            with pytest.raises(requests.exceptions.ReadTimeout):
-                session.get(f"http://127.0.0.1:{port}/")
-        finally:
-            stop.set()
-            srv.close()

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -161,6 +161,13 @@ class TestHondaAuthLogin:
         with pytest.raises(HondaAuthError, match="register failed"):
             auth.register_device("user@test.com", "pass123")
 
+    def test_uses_configured_request_timeout(self):
+        auth = HondaAuth(device_key=DeviceKey(), request_timeout=2.5)
+        adapter = auth.session.get_adapter("https://example.com")
+
+        assert auth.request_timeout == 2.5
+        assert adapter._timeout == 2.5
+
 
 class TestHondaAuthErrorInheritance:
 

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -56,7 +56,7 @@ class _FakeAPI:
 def _patch_common(monkeypatch, fake_api):
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.0")
     monkeypatch.setattr(cli, "get_storage", lambda *args, **kwargs: object())
-    monkeypatch.setattr(cli, "HondaAPI", lambda storage=None: fake_api)
+    monkeypatch.setattr(cli, "HondaAPI", lambda storage=None, request_timeout=None: fake_api)
 
 
 def test_multi_vehicle_without_vin_exits_with_message(monkeypatch, capsys):
@@ -223,7 +223,7 @@ def test_login_auth_failure_returns_2(monkeypatch, capsys):
     monkeypatch.setattr(cli.sys, "argv", ["pymyhondaplus", "login", "--email", "user@example.com", "--password", "secret"])
 
     class _FakeAuth:
-        def __init__(self, device_key=None):
+        def __init__(self, device_key=None, request_timeout=None):
             pass
 
         def full_login(self, email: str, password: str, locale: str = "it"):
@@ -237,6 +237,62 @@ def test_login_auth_failure_returns_2(monkeypatch, capsys):
     err = capsys.readouterr().err
     assert rc == 2
     assert "Login failed: HTTP 401: bad credentials" in err
+
+
+def test_http_timeout_is_forwarded_to_clients(monkeypatch, capsys):
+    recorded = {}
+
+    class _FakeAuth:
+        def __init__(self, device_key=None, request_timeout=None):
+            recorded["auth_timeout"] = request_timeout
+
+        def full_login(self, email: str, password: str, locale: str = "it"):
+            return {
+                "access_token": "header.eyJzdWIiOiAidXNlci0xIn0.signature",
+                "refresh_token": "refresh",
+                "expires_in": 3600,
+            }
+
+        @staticmethod
+        def extract_user_id(token: str) -> str:
+            return "user-1"
+
+    class _FakeAPI:
+        def __init__(self, storage=None, request_timeout=None):
+            recorded.setdefault("api_timeouts", []).append(request_timeout)
+            self.tokens = type("Tokens", (), {"vehicles": []})()
+
+        def set_tokens(self, **kwargs):
+            return None
+
+        def get_vehicles(self):
+            return []
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.0")
+    monkeypatch.setattr(cli, "get_storage", lambda *args, **kwargs: object())
+    monkeypatch.setattr(cli, "DeviceKey", lambda storage=None: object())
+    monkeypatch.setattr(cli, "HondaAuth", _FakeAuth)
+    monkeypatch.setattr(cli, "HondaAPI", _FakeAPI)
+    monkeypatch.setattr(
+        cli.sys,
+        "argv",
+        [
+            "pymyhondaplus",
+            "login",
+            "--email",
+            "user@example.com",
+            "--password",
+            "secret",
+            "--http-timeout",
+            "4.5",
+        ],
+    )
+
+    rc = cli.main()
+
+    assert rc == 0
+    assert recorded["auth_timeout"] == 4.5
+    assert recorded["api_timeouts"] == [4.5]
 
 
 def test__main_exits_130_on_keyboard_interrupt(monkeypatch):

--- a/tests/test_cli_trip_stats.py
+++ b/tests/test_cli_trip_stats.py
@@ -49,7 +49,7 @@ def test_trip_stats_week_fetches_all_months_in_range(monkeypatch, capsys):
 
     monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.0")
     monkeypatch.setattr(cli, "get_storage", lambda *args, **kwargs: object())
-    monkeypatch.setattr(cli, "HondaAPI", lambda storage=None: fake_api)
+    monkeypatch.setattr(cli, "HondaAPI", lambda storage=None, request_timeout=None: fake_api)
     monkeypatch.setattr(
         cli.sys,
         "argv",


### PR DESCRIPTION
Introduces a `_TimeoutAdapter` class (extending `HTTPAdapter`) that enforces a default 10-second timeout on all HTTP requests. Mounted on both API and auth sessions to prevent indefinite hangs when Honda's servers are unresponsive.

Retries are scoped to 5xx status responses only (`status=3`); transport-level errors (timeouts, connection failures) are not retried, so a stalled server fails fast after 10 seconds.

Resolves #2