### PR TITLE
Add GitHub issue templates and PR template

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.yml
+++ b/.github/ISSUE_TEMPLATE/bug_report.yml
@@ -1,0 +1,95 @@
+name: Bug Report
+description: Report a bug or unexpected behaviour
+title: "[Bug]: "
+labels: ["bug"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for reporting a bug! Please fill in as much detail as you can
+        so we can reproduce and fix the issue.
+
+  - type: input
+    id: version
+    attributes:
+      label: pymyhondaplus version
+      description: >
+        Run `pip show pymyhondaplus` or check `pymyhondaplus --version`.
+      placeholder: "e.g. 5.3.1"
+    validations:
+      required: true
+
+  - type: input
+    id: python_version
+    attributes:
+      label: Python version
+      description: Output of `python --version`.
+      placeholder: "e.g. 3.12.3"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: vehicle_model
+    attributes:
+      label: Vehicle model
+      description: Select your Honda model.
+      options:
+        - "Honda e"
+        - "e:Ny1"
+        - "ZR-V"
+        - "CR-V"
+        - "Civic"
+        - "HR-V"
+        - "Jazz"
+        - "Other (specify below)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: usage
+    attributes:
+      label: How are you using the library?
+      options:
+        - "CLI (command line)"
+        - "Python API (import pymyhondaplus)"
+        - "Both"
+    validations:
+      required: true
+
+  - type: textarea
+    id: description
+    attributes:
+      label: Description
+      description: A clear description of the bug.
+      placeholder: What happened? What did you expect to happen?
+    validations:
+      required: true
+
+  - type: textarea
+    id: steps
+    attributes:
+      label: Steps to reproduce
+      description: >
+        The exact command or code snippet that triggers the bug.
+      placeholder: |
+        1. Run `pymyhondaplus status`
+        2. See error ...
+    validations:
+      required: true
+
+  - type: textarea
+    id: logs
+    attributes:
+      label: Error output / traceback
+      description: >
+        Paste the full error output. **Remove or redact any personal
+        information** (email, VIN, tokens, coordinates).
+      render: shell
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: >
+        Any other information that might help — OS, network setup, whether
+        the My Honda+ mobile app works at the same time, etc.

--- a/.github/ISSUE_TEMPLATE/feature_request.yml
+++ b/.github/ISSUE_TEMPLATE/feature_request.yml
@@ -1,0 +1,59 @@
+name: Feature Request
+description: Suggest a new feature or enhancement
+title: "[Feature]: "
+labels: ["enhancement"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Have an idea to improve pymyhondaplus? We'd love to hear it!
+
+  - type: textarea
+    id: problem
+    attributes:
+      label: Problem or motivation
+      description: >
+        What problem does this feature solve, or what use case does it enable?
+      placeholder: "I'd like to be able to ..."
+    validations:
+      required: true
+
+  - type: textarea
+    id: solution
+    attributes:
+      label: Proposed solution
+      description: >
+        Describe how you'd like this to work — CLI flags, API methods,
+        output format, etc.
+    validations:
+      required: true
+
+  - type: dropdown
+    id: area
+    attributes:
+      label: Area
+      description: Which part of the project does this relate to?
+      options:
+        - "CLI"
+        - "Python API"
+        - "Authentication"
+        - "Translations / i18n"
+        - "Documentation"
+        - "Other"
+    validations:
+      required: true
+
+  - type: textarea
+    id: alternatives
+    attributes:
+      label: Alternatives considered
+      description: >
+        Any workarounds or alternative approaches you've thought about.
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: >
+        Any other context, screenshots, or references that help explain
+        the request.

--- a/.github/ISSUE_TEMPLATE/translation.yml
+++ b/.github/ISSUE_TEMPLATE/translation.yml
@@ -1,0 +1,73 @@
+name: Translation
+description: Add a new language or fix an existing translation
+title: "Add or fix translation: [language]"
+labels: ["translation"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        Thanks for helping translate pymyhondaplus!
+        Translations live in `src/pymyhondaplus/translations.py` inside the
+        `TRANSLATIONS` dictionary. Please fill in the fields below.
+
+  - type: dropdown
+    id: language
+    attributes:
+      label: Language
+      description: Select the language you are contributing.
+      options:
+        - "Czech (cs)"
+        - "Danish (da)"
+        - "Dutch (nl)"
+        - "English (en)"
+        - "French (fr)"
+        - "German (de)"
+        - "Hungarian (hu)"
+        - "Italian (it)"
+        - "Norwegian (no)"
+        - "Polish (pl)"
+        - "Slovak (sk)"
+        - "Spanish (es)"
+        - "Swedish (sv)"
+        - "Other (specify in notes)"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: contribution_type
+    attributes:
+      label: Contribution type
+      options:
+        - "New translation"
+        - "Fix / improve existing translation"
+    validations:
+      required: true
+
+  - type: textarea
+    id: corrections
+    attributes:
+      label: Corrections
+      description: >
+        **For fixes only.** List the keys and their corrected values.
+        Use the Python dictionary key so the change is unambiguous.
+      placeholder: |
+        TRANSLATIONS["de"]["battery_label"]: "Batterie" -> "Akkustand (%)"
+        TRANSLATIONS["de"]["climate_label"]: "old text" -> "corrected text"
+
+  - type: textarea
+    id: translation_full
+    attributes:
+      label: Full translation dictionary
+      description: >
+        **For new translations only.** Copy the `"en"` block from
+        [`translations.py`](https://github.com/enricobattocchi/pymyhondaplus/blob/main/src/pymyhondaplus/translations.py),
+        translate the values (not the keys), and paste the result here.
+      render: python
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Notes
+      description: >
+        Any additional context — e.g. regional variants, partial translation,
+        source of the translation strings.

--- a/.github/ISSUE_TEMPLATE/vehicle_compatibility.yml
+++ b/.github/ISSUE_TEMPLATE/vehicle_compatibility.yml
@@ -1,0 +1,90 @@
+name: Vehicle Compatibility Report
+description: Report how well pymyhondaplus works with your Honda model
+title: "[Compatibility]: "
+labels: ["compatibility"]
+body:
+  - type: markdown
+    attributes:
+      value: |
+        This library is tested primarily on Honda e. If you use a different
+        Honda Connect Europe vehicle, your feedback helps us improve support
+        for all models. Thanks!
+
+  - type: dropdown
+    id: vehicle_model
+    attributes:
+      label: Vehicle model
+      description: Select your Honda model.
+      options:
+        - "Honda e"
+        - "e:Ny1"
+        - "ZR-V"
+        - "CR-V"
+        - "Civic"
+        - "HR-V"
+        - "Jazz"
+        - "Other (specify below)"
+    validations:
+      required: true
+
+  - type: input
+    id: model_year
+    attributes:
+      label: Model year
+      placeholder: "e.g. 2024"
+    validations:
+      required: true
+
+  - type: input
+    id: version
+    attributes:
+      label: pymyhondaplus version
+      placeholder: "e.g. 5.3.1"
+    validations:
+      required: true
+
+  - type: dropdown
+    id: powertrain
+    attributes:
+      label: Powertrain
+      options:
+        - "Full EV"
+        - "Hybrid (e:HEV)"
+        - "Petrol"
+    validations:
+      required: true
+
+  - type: checkboxes
+    id: working_features
+    attributes:
+      label: Working features
+      description: Check the features that work correctly on your vehicle.
+      options:
+        - label: "Authentication & login"
+        - label: "Vehicle status (doors, windows, lights)"
+        - label: "Battery / fuel level"
+        - label: "Location"
+        - label: "Remote lock / unlock"
+        - label: "Remote horn / hazards"
+        - label: "Climate control"
+        - label: "Charging status & schedules (EV/PHEV)"
+        - label: "Trip history & statistics"
+
+  - type: textarea
+    id: issues
+    attributes:
+      label: Issues or missing data
+      description: >
+        Describe any commands that fail, fields that return unexpected values,
+        or data that is missing compared to the My Honda+ app.
+      placeholder: |
+        - `status` shows battery level as "N/A"
+        - `trips` returns empty list even though app shows trips
+
+  - type: textarea
+    id: notes
+    attributes:
+      label: Additional context
+      description: >
+        Any other details — firmware version, region, screenshots comparing
+        app vs CLI output, etc.

--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,24 @@
+## Summary
+
+<!-- Briefly describe what this PR does and why. -->
+
+## Type of change
+
+- [ ] Bug fix
+- [ ] New feature
+- [ ] Translation (new or improved)
+- [ ] Refactoring (no functional change)
+- [ ] Documentation
+- [ ] Other: <!-- describe -->
+
+## Vehicle model tested
+
+<!-- If applicable, which Honda model did you test with? -->
+
+## Checklist
+
+- [ ] I have tested my changes locally
+- [ ] Tests pass: `pytest -v`
+- [ ] Linting passes: `ruff check src/ tests/`
+- [ ] Type checking passes: `mypy src/pymyhondaplus/`
+- [ ] I have **not** committed credentials, tokens, or personal data


### PR DESCRIPTION
## Summary

This PR adds standardized GitHub issue templates and a pull request template to improve the contribution workflow and issue reporting process for the pymyhondaplus project.

## Key changes

- **Bug Report template** (`bug_report.yml`): Structured form for reporting bugs with fields for version info, Python version, vehicle model, usage context, reproduction steps, error logs, and additional context
- **Vehicle Compatibility Report template** (`vehicle_compatibility.yml`): Dedicated template for reporting compatibility across different Honda models, including powertrain type and feature checklist
- **Feature Request template** (`feature_request.yml`): Template for suggesting new features with sections for problem statement, proposed solution, affected area, and alternatives
- **Translation template** (`translation.yml`): Template for contributing new translations or fixing existing ones, with support for multiple languages
- **Pull Request template** (`pull_request_template.md`): Standard PR template with sections for summary, change type, vehicle testing, and pre-submission checklist including testing and linting requirements

## Notable implementation details

- All issue templates use YAML format with appropriate labels (`bug`, `compatibility`, `enhancement`, `translation`)
- Templates include helpful descriptions and placeholders to guide contributors
- The PR template includes reminders about security (no credentials/tokens) and quality checks (pytest, ruff, mypy)
- Vehicle compatibility template provides a comprehensive feature checklist covering authentication, status, battery, location, remote controls, climate, charging, and trip history
- Translation template references the actual location of translations in the codebase and provides language options matching supported locales

https://claude.ai/code/session_01QiWopS8ZJT4YHALddheTFv