### PR TITLE
Normalize EVStatus fields and release 5.8.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.7.1b1 — 2026-04-14
+
+- Normalize EVStatus fields and add missing vehicle capabilities
+
 ## 5.7.0 — 2026-04-13
 
 - Add `activate_status` and `deactivate_status` fields to `Geofence` dataclass (maps `activateAsyncCommandStatus` / `deactivateAsyncCommandStatus` from the API)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,14 +2,20 @@
 
 All notable changes to this project will be documented in this file.
 
-## 5.7.1b2 — 2026-04-24
+## 5.8.0 — 2026-04-24
 
+- Convert DMS-with-commas GPS coordinates to decimal degrees in `parse_ev_status` (`EVStatus.latitude` and `EVStatus.longitude` changed from `str` to `float`).
+- Refactor the CLI `location` command to use `EVStatus` instead of raw API data.
+- Normalize `EVStatus.home_away` to `home` / `away` / `unknown` (fixes "home is unregistered").
+- Normalize `EVStatus.climate_temp`: map known labels, pass through numeric values from specific-temperature vehicles, fall back to `"unknown"`.
+- Add 17 newly discovered vehicle capabilities to `VehicleCapabilities`.
 - Normalize `EVStatus.charge_status` to a canonical enum (`charging`, `stopped`, `unknown`). The raw API returns values like `running` / `unavailable` which previously leaked through and broke downstream consumers declaring strict enum sensors (e.g. the Home Assistant integration).
 - Mapping: `running` → `charging`, `stopped` → `stopped`, `unavailable` / missing / unexpected values → `unknown` (with a DEBUG log for unexpected values).
 - CLI `CHARGE_STATUS_MAP` (in `translations.py`) is now keyed by the normalized values rather than raw API values.
 
 ### Migration notes for library consumers
 
+- `EVStatus.latitude` / `EVStatus.longitude` are now `float`. Consumers doing string comparisons or concatenation must update.
 - `EVStatus.charge_status` will no longer emit `"running"` or `"unavailable"`. Consumers that branched on these raw values should switch to `"charging"` / `"unknown"`.
 
 ## 5.7.1b1 — 2026-04-14

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,16 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.7.1b2 — 2026-04-24
+
+- Normalize `EVStatus.charge_status` to a canonical enum (`charging`, `stopped`, `unknown`). The raw API returns values like `running` / `unavailable` which previously leaked through and broke downstream consumers declaring strict enum sensors (e.g. the Home Assistant integration).
+- Mapping: `running` → `charging`, `stopped` → `stopped`, `unavailable` / missing / unexpected values → `unknown` (with a DEBUG log for unexpected values).
+- CLI `CHARGE_STATUS_MAP` (in `translations.py`) is now keyed by the normalized values rather than raw API values.
+
+### Migration notes for library consumers
+
+- `EVStatus.charge_status` will no longer emit `"running"` or `"unavailable"`. Consumers that branched on these raw values should switch to `"charging"` / `"unknown"`.
+
 ## 5.7.1b1 — 2026-04-14
 
 - Normalize EVStatus fields and add missing vehicle capabilities

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.7.1b2"
+version = "5.8.0"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.7.0"
+version = "5.7.1b1"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.7.1b1"
+version = "5.7.1b2"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -96,6 +96,34 @@ def _normalize_climate_temp(raw: str) -> str:
         return "unknown"
 
 
+# Raw API chargeStatus values -> canonical enum values exposed on EVStatus.
+# Downstream consumers (e.g. the Home Assistant integration) declare ENUM
+# sensors against the canonical set, so unexpected raw values collapse to
+# "unknown" rather than leaking through.
+_CHARGE_STATUS_MAP = {
+    "running": "charging",
+    "stopped": "stopped",
+    "unavailable": "unknown",
+    "unknown": "unknown",
+}
+
+
+def _normalize_charge_status(raw) -> str:
+    """Normalize a raw chargeStatus API value to a canonical enum value."""
+    if not isinstance(raw, str):
+        if raw is not None:
+            logger.debug(
+                "Unexpected chargeStatus type %s (%r); treating as unknown",
+                type(raw).__name__, raw,
+            )
+        return "unknown"
+    key = raw.strip().lower()
+    if key in _CHARGE_STATUS_MAP:
+        return _CHARGE_STATUS_MAP[key]
+    logger.debug("Unexpected chargeStatus value %r; treating as unknown", raw)
+    return "unknown"
+
+
 @dataclass
 class AuthTokens:
     access_token: str = ""
@@ -1375,7 +1403,7 @@ def parse_ev_status(dashboard: dict) -> EVStatus:
         distance_unit=distance_unit,
         speed_unit=speed_unit,
         temp_unit=temp_unit,
-        charge_status=ev.get("chargeStatus", "unknown"),
+        charge_status=_normalize_charge_status(ev.get("chargeStatus")),
         plug_status=ev.get("plugStatus", "unknown"),
         home_away=ev.get("homeAway", "unknown").lower()
             if ev.get("homeAway", "unknown").lower() in ("home", "away")

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -62,6 +62,40 @@ def _format_hhmm(raw: str) -> str:
     return f"{digits[:2]}:{digits[2:4]}"
 
 
+def _dms_to_decimal(dms: str) -> float:
+    """Convert a DMS-with-commas string (e.g. '43,33,11.902') to decimal degrees."""
+    if not dms:
+        return 0.0
+    try:
+        parts = dms.split(",")
+        if len(parts) != 3:
+            return float(dms)
+        deg, minutes, seconds = parts
+        sign = -1 if deg.startswith("-") else 1
+        return sign * (abs(float(deg)) + float(minutes) / 60 + float(seconds) / 3600)
+    except (ValueError, IndexError):
+        return 0.0
+
+
+_CLIMATE_TEMP_MAP = {
+    "05": "cooler", "04": "normal", "03": "hotter",
+    "cool": "cooler", "normal": "normal", "warm": "hotter",
+    "cooler": "cooler", "hotter": "hotter",
+}
+
+
+def _normalize_climate_temp(raw: str) -> str:
+    """Normalize acTempVal: map known labels, pass through numeric values."""
+    label = _CLIMATE_TEMP_MAP.get(raw)
+    if label:
+        return label
+    try:
+        float(raw)
+        return raw
+    except (ValueError, TypeError):
+        return "unknown"
+
+
 @dataclass
 class AuthTokens:
     access_token: str = ""
@@ -170,6 +204,23 @@ class VehicleCapabilities:
     journey_history: bool = False
     send_poi: bool = False
     geo_fence: bool = False
+    specific_temperature: bool = False
+    climate_adjusted_range: bool = False
+    display_phev_range: bool = False
+    smart_charge: bool = False
+    remote_engine: bool = False
+    care_assistance: bool = False
+    digital_key_lock_unlock: bool = False
+    digital_key_open_charge_lid: bool = False
+    digital_key_close_power_windows: bool = False
+    digital_key_open_power_windows: bool = False
+    digital_key_stop_power_windows: bool = False
+    digital_key_power_on_guidance: bool = False
+    digital_key_power_on_guidance_manual: bool = False
+    digital_key_start_authentication: bool = False
+    digital_key_leave_notifications: bool = False
+    suppress_lid_open_warning: bool = False
+    hide_open_charge_lid_button: bool = False
     raw: dict = field(default_factory=dict, repr=False)
 
     @classmethod
@@ -193,6 +244,23 @@ class VehicleCapabilities:
             journey_history=_active("telematicsJourneyHistory"),
             send_poi=_active("telematicsSendPoi"),
             geo_fence=_active("telematicsGeoFence"),
+            specific_temperature=_active("useSpecificTemperatureControl"),
+            climate_adjusted_range=_active("useClimateAdjustedRange"),
+            display_phev_range=_active("displayPhevRange"),
+            smart_charge=_active("smartCharge"),
+            remote_engine=_active("telematicsUseRemoteEngineApi"),
+            care_assistance=_active("telematicsCareAssistance"),
+            digital_key_lock_unlock=_active("digitalKeyLockUnlock"),
+            digital_key_open_charge_lid=_active("digitalKeyOpenChargeLid"),
+            digital_key_close_power_windows=_active("digitalKeyClosePowerWindows"),
+            digital_key_open_power_windows=_active("digitalKeyOpenPowerWindows"),
+            digital_key_stop_power_windows=_active("digitalKeyStopPowerWindows"),
+            digital_key_power_on_guidance=_active("digitalKeyPowerOnGuidance"),
+            digital_key_power_on_guidance_manual=_active("digitalKeyPowerOnGuidanceManual"),
+            digital_key_start_authentication=_active("digitalKeyStartAuthentication"),
+            digital_key_leave_notifications=_active("digitalKeyLeaveNotifications"),
+            suppress_lid_open_warning=_active("suppressLidOpenWarning"),
+            hide_open_charge_lid_button=_active("hideOpenChargeLidButton"),
             raw=caps,
         )
 
@@ -210,6 +278,23 @@ class VehicleCapabilities:
             "journey_history": self.journey_history,
             "send_poi": self.send_poi,
             "geo_fence": self.geo_fence,
+            "specific_temperature": self.specific_temperature,
+            "climate_adjusted_range": self.climate_adjusted_range,
+            "display_phev_range": self.display_phev_range,
+            "smart_charge": self.smart_charge,
+            "remote_engine": self.remote_engine,
+            "care_assistance": self.care_assistance,
+            "digital_key_lock_unlock": self.digital_key_lock_unlock,
+            "digital_key_open_charge_lid": self.digital_key_open_charge_lid,
+            "digital_key_close_power_windows": self.digital_key_close_power_windows,
+            "digital_key_open_power_windows": self.digital_key_open_power_windows,
+            "digital_key_stop_power_windows": self.digital_key_stop_power_windows,
+            "digital_key_power_on_guidance": self.digital_key_power_on_guidance,
+            "digital_key_power_on_guidance_manual": self.digital_key_power_on_guidance_manual,
+            "digital_key_start_authentication": self.digital_key_start_authentication,
+            "digital_key_leave_notifications": self.digital_key_leave_notifications,
+            "suppress_lid_open_warning": self.suppress_lid_open_warning,
+            "hide_open_charge_lid_button": self.hide_open_charge_lid_button,
         }
 
     @classmethod
@@ -1240,8 +1325,8 @@ class EVStatus:
     cabin_temp: int = 0
     interior_temp: int = 0
     odometer: int = 0
-    latitude: str = ""
-    longitude: str = ""
+    latitude: float = 0.0
+    longitude: float = 0.0
     timestamp: str = ""
     doors_locked: bool = True
     all_doors_closed: bool = True
@@ -1292,15 +1377,17 @@ def parse_ev_status(dashboard: dict) -> EVStatus:
         temp_unit=temp_unit,
         charge_status=ev.get("chargeStatus", "unknown"),
         plug_status=ev.get("plugStatus", "unknown"),
-        home_away=ev.get("homeAway", "unknown").lower(),
+        home_away=ev.get("homeAway", "unknown").lower()
+            if ev.get("homeAway", "unknown").lower() in ("home", "away")
+            else "unknown",
         charge_limit_home=_safe_int(ev.get("chargeLimitHome", 0)),
         charge_limit_away=_safe_int(ev.get("chargeLimitAway", 0)),
         climate_active=dashboard.get("climateControl", {}).get("status", {}).get("isActive", False),
         cabin_temp=_safe_int(dashboard.get("temperature", {}).get("cabin", {}).get("value", 0)),
         interior_temp=_safe_int(ev.get("intTemp", 0)),
         odometer=_safe_int(dashboard.get("odometer", {}).get("value", 0)),
-        latitude=coord.get("latitude", ""),
-        longitude=coord.get("longitude", ""),
+        latitude=_dms_to_decimal(coord.get("latitude", "")),
+        longitude=_dms_to_decimal(coord.get("longitude", "")),
         timestamp=dashboard.get("timestamp", ""),
         doors_locked=all(
             door.get("lockState") == "lock"
@@ -1335,9 +1422,7 @@ def parse_ev_status(dashboard: dict) -> EVStatus:
             if msg.get("condition") == "ON"
         ],
         speed=_safe_float(gps.get("velocity", {}).get("value", 0)),
-        climate_temp={"05": "cooler", "04": "normal", "03": "hotter",
-                      "cool": "cooler", "warm": "hotter"}.get(
-            ev.get("acTempVal", "normal"), ev.get("acTempVal", "unknown")),
+        climate_temp=_normalize_climate_temp(ev.get("acTempVal", "normal")),
         climate_duration=_safe_int(ev.get("acDurationSetting", 0)),
         climate_defrost=ev.get("acDefAutoSetting", "").lower().startswith("def auto on"),
     )

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -17,7 +17,7 @@ from pathlib import Path
 try:
     import argcomplete
 except ImportError:
-    argcomplete = None
+    argcomplete = None  # type: ignore[assignment]
 
 from .api import DEFAULT_TOKEN_FILE, HondaAPI, HondaAPIError, HondaAuthError, compute_trip_stats, parse_ev_status
 from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -260,7 +260,7 @@ def _handle_status_command(api: HondaAPI, vin: str, args: argparse.Namespace) ->
         rows.append((t("time_remaining_label"), f"{ev['time_to_charge']} {t('mins')}"))
     rows += [
         (t("location_label"), t("home") if ev['home_away'] == "home" else t("away_location", raw=ev['home_away'])),
-        (t("coordinates_label"), f"{ev['latitude']}, {ev['longitude']}"),
+        (t("coordinates_label"), f"{ev['latitude']:.6f}, {ev['longitude']:.6f}"),
         (t("charge_limit_label"), f"{ev['charge_limit_home']}% ({home}) / {ev['charge_limit_away']}% ({away})"),
         (t("climate_label"), _translate_field('climate_active', ev['climate_active'], t)),
         (t("cabin_temp_label"), f"{ev['cabin_temp']} {tu}"),
@@ -295,12 +295,11 @@ def _handle_location_command(api: HondaAPI, vin: str, args: argparse.Namespace) 
         print(json.dumps(gps, indent=2))
         return 0
 
-    coord = gps.get("coordinate", {})
-    print(f"Latitude:  {coord.get('latitude', 'N/A')}")
-    print(f"Longitude: {coord.get('longitude', 'N/A')}")
-    speed_unit = gps.get('velocity', {}).get('unit', 'km/h')
-    print(f"Speed:     {gps.get('velocity', {}).get('value', 'N/A')} {speed_unit}")
-    print(f"Timestamp: {gps.get('dtTime', 'N/A')}")
+    ev = parse_ev_status(dashboard)
+    print(f"Latitude:  {ev['latitude']:.6f}")
+    print(f"Longitude: {ev['longitude']:.6f}")
+    print(f"Speed:     {ev['speed']} {ev['speed_unit']}")
+    print(f"Timestamp: {gps.get('dtTime', ev['timestamp'])}")
     return 0
 
 

--- a/src/pymyhondaplus/translations.py
+++ b/src/pymyhondaplus/translations.py
@@ -1788,12 +1788,12 @@ CHARGE_MODE_MAP = {
     "fast charging": "charge_speed_fast",
 }
 
-# Map raw API chargeStatus values to translation keys.
-# Possible values (from enums): unknown, stopped, running, unavailable.
+# Map normalized charge_status values (as exposed on EVStatus) to CLI
+# translation keys. parse_ev_status normalizes the raw API chargeStatus
+# (running/stopped/unavailable/unknown) to the canonical enum used here.
 CHARGE_STATUS_MAP = {
-    "running": "charging",
+    "charging": "charging",
     "stopped": "not_charging",
-    "unavailable": "unavailable",
     "unknown": "unknown",
 }
 

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -18,8 +18,8 @@ def dashboard_ev():
         "timestamp": "2026-03-24T22:53:01+00:00",
         "gpsData": {
             "coordinate": {
-                "latitude": "41.890251",
-                "longitude": "12.492373",
+                "latitude": "41,53,24.904",
+                "longitude": "12,29,32.543",
             },
             "dtTime": "2026-03-24T22:53:01+00:00",
             "velocity": {"value": "0.0", "unit": "km/h"},

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -27,7 +27,7 @@ class _FakeAPI:
     def get_dashboard(self, vin: str, fresh: bool = False):
         return {
             "gpsData": {
-                "coordinate": {"latitude": "41.890251", "longitude": "12.492373"},
+                "coordinate": {"latitude": "41,53,24.904", "longitude": "12,29,32.543"},
                 "dtTime": "2026-03-24T22:53:01+00:00",
                 "velocity": {"value": "0.0", "unit": "km/h"},
             }
@@ -106,7 +106,7 @@ def test_location_json_outputs_raw_gps_payload(monkeypatch, capsys):
     out = capsys.readouterr()
     assert rc == 0
     assert '"coordinate": {' in out.out
-    assert '"latitude": "41.890251"' in out.out
+    assert '"latitude": "41,53,24.904"' in out.out
     assert '"dtTime": "2026-03-24T22:53:01+00:00"' in out.out
 
 
@@ -125,7 +125,7 @@ def test_status_json_outputs_raw_dashboard(monkeypatch, capsys):
     assert rc == 0
     assert '"gpsData": {' in out.out
     assert '"coordinate": {' in out.out
-    assert '"latitude": "41.890251"' in out.out
+    assert '"latitude": "41,53,24.904"' in out.out
 
 
 def test_climate_settings_json_outputs_parsed_fields(monkeypatch, capsys):

--- a/tests/test_parse_ev_status.py
+++ b/tests/test_parse_ev_status.py
@@ -110,6 +110,55 @@ def test_climate_temp_mapping(dashboard_ev):
     assert parse_ev_status(dashboard_ev)["climate_temp"] == "normal"
 
 
+def test_charge_status_running_normalized_to_charging(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = "running"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "charging"
+
+
+def test_charge_status_stopped_passes_through(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = "stopped"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "stopped"
+
+
+def test_charge_status_unavailable_normalized_to_unknown(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = "unavailable"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+
+
+def test_charge_status_unknown_passes_through(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = "unknown"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+
+
+def test_charge_status_case_insensitive(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = "RUNNING"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "charging"
+
+    dashboard_ev["evStatus"]["chargeStatus"] = "Stopped"
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "stopped"
+
+
+def test_charge_status_missing_is_unknown(dashboard_ev):
+    dashboard_ev["evStatus"].pop("chargeStatus", None)
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+
+
+def test_charge_status_unexpected_value_is_unknown(dashboard_ev, caplog):
+    import logging
+    dashboard_ev["evStatus"]["chargeStatus"] = "weird-new-state"
+    with caplog.at_level(logging.DEBUG, logger="pymyhondaplus.api"):
+        assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+    assert any("weird-new-state" in rec.message for rec in caplog.records)
+
+
+def test_charge_status_non_string_is_unknown(dashboard_ev):
+    dashboard_ev["evStatus"]["chargeStatus"] = 42
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+
+    dashboard_ev["evStatus"]["chargeStatus"] = None
+    assert parse_ev_status(dashboard_ev)["charge_status"] == "unknown"
+
+
 def test_climate_defrost_off(dashboard_ev):
     dashboard_ev["evStatus"]["acDefAutoSetting"] = "def auto off"
     ev = parse_ev_status(dashboard_ev)

--- a/tests/test_parse_ev_status.py
+++ b/tests/test_parse_ev_status.py
@@ -28,8 +28,8 @@ def test_temperature(dashboard_ev):
 
 def test_gps(dashboard_ev):
     ev = parse_ev_status(dashboard_ev)
-    assert ev["latitude"] == "41.890251"
-    assert ev["longitude"] == "12.492373"
+    assert abs(ev["latitude"] - 41.890251) < 0.000001
+    assert abs(ev["longitude"] - 12.492373) < 0.000001
     assert ev["speed"] == 0.0
     assert ev["speed_unit"] == "km/h"
     assert ev["distance_unit"] == "km"
@@ -136,6 +136,33 @@ def test_empty_dashboard():
     assert ev["doors_locked"] is True  # all() on empty is True
     assert ev["lights_on"] is False
     assert ev["warning_lamps"] == []
+
+
+def test_home_away_normalization(dashboard_ev):
+    dashboard_ev["evStatus"]["homeAway"] = "Home"
+    assert parse_ev_status(dashboard_ev)["home_away"] == "home"
+
+    dashboard_ev["evStatus"]["homeAway"] = "Away"
+    assert parse_ev_status(dashboard_ev)["home_away"] == "away"
+
+    dashboard_ev["evStatus"]["homeAway"] = "home is unregistered"
+    assert parse_ev_status(dashboard_ev)["home_away"] == "unknown"
+
+    dashboard_ev["evStatus"]["homeAway"] = "something unexpected"
+    assert parse_ev_status(dashboard_ev)["home_away"] == "unknown"
+
+
+def test_climate_temp_numeric_passes_through(dashboard_ev):
+    dashboard_ev["evStatus"]["acTempVal"] = "17"
+    assert parse_ev_status(dashboard_ev)["climate_temp"] == "17"
+
+    dashboard_ev["evStatus"]["acTempVal"] = "25.5"
+    assert parse_ev_status(dashboard_ev)["climate_temp"] == "25.5"
+
+
+def test_climate_temp_garbage_normalized_to_unknown(dashboard_ev):
+    dashboard_ev["evStatus"]["acTempVal"] = "not a temp"
+    assert parse_ev_status(dashboard_ev)["climate_temp"] == "unknown"
 
 
 def test_malformed_numeric_fields_do_not_crash(dashboard_ev):

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -97,13 +97,13 @@ def test_c_locale_falls_back_to_english(monkeypatch):
 
 def test_charge_status_map():
     t = get_translator("en")
-    assert t(CHARGE_STATUS_MAP["running"]) == "Charging"
+    assert t(CHARGE_STATUS_MAP["charging"]) == "Charging"
     assert t(CHARGE_STATUS_MAP["stopped"]) == "Not charging"
 
 
 def test_charge_status_map_german():
     t = get_translator("de")
-    assert t(CHARGE_STATUS_MAP["running"]) == "Wird geladen"
+    assert t(CHARGE_STATUS_MAP["charging"]) == "Wird geladen"
     assert t(CHARGE_STATUS_MAP["stopped"]) == "Wird nicht geladen"
 
 
@@ -121,11 +121,10 @@ def test_plug_status_mapped():
 
 
 def test_charge_status_all_mapped():
-    """All known charge status values should be mapped."""
+    """All normalized charge status values should be mapped."""
     t = get_translator("en")
-    assert t(CHARGE_STATUS_MAP["running"]) == "Charging"
+    assert t(CHARGE_STATUS_MAP["charging"]) == "Charging"
     assert t(CHARGE_STATUS_MAP["stopped"]) == "Not charging"
-    assert t(CHARGE_STATUS_MAP["unavailable"]) == "Unavailable"
     assert t(CHARGE_STATUS_MAP["unknown"]) == "Unknown"
 
 


### PR DESCRIPTION
## Summary

Normalizes several `EVStatus` fields to emit predictable, canonical values instead of leaking raw API quirks through to downstream consumers (notably the Home Assistant integration, which declares strict enum sensors).

## Changes

- **`charge_status`** normalized to `charging` / `stopped` / `unknown`. Raw API values (`running`, `stopped`, `unavailable`, `unknown`) are mapped; unexpected values collapse to `unknown` with a DEBUG log. Fixes [myhondaplus-homeassistant#21](https://github.com/enricobattocchi/myhondaplus-homeassistant/issues/21).
- **`home_away`** normalized to `home` / `away` / `unknown` (fixes the "home is unregistered" raw value leaking through). Fixes [myhondaplus-homeassistant#18](https://github.com/enricobattocchi/myhondaplus-homeassistant/issues/18).
- **`climate_temp`** normalized: known preset labels mapped, numeric values from specific-temperature vehicles pass through, unexpected inputs fall back to `"unknown"`.
- **`latitude` / `longitude`** now `float` (decimal degrees) instead of DMS-with-commas strings. CLI `location` command refactored to consume `EVStatus` directly.
- **`VehicleCapabilities`** gains 17 newly discovered feature flags (digital key, PHEV, specific-temperature, home-location, etc.).
- CLI `CHARGE_STATUS_MAP` in `translations.py` is re-keyed by normalized values.
- Fix pre-existing mypy error on the `argcomplete` optional import.

## Version

5.8.0. The `5.7.1b1` pre-release is superseded.

## Breaking changes

- `EVStatus.latitude` / `EVStatus.longitude` are now `float`.
- `EVStatus.charge_status` no longer emits `"running"` or `"unavailable"` — consumers must update to `"charging"` / `"unknown"`.
- `EVStatus.home_away` is always one of `home` / `away` / `unknown`.

See CHANGELOG for full migration notes.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `mypy src/pymyhondaplus/` clean
- [x] `pytest` — 211 tests pass
- [x] Verified `myhondaplus-desktop` is already compatible with the normalized values (translation keys `dashboard.val.charging` and `dashboard.val.stopped` exist in all 13 locales)