### PR TITLE
Release 5.8.2: wait for geofence async status to reach a terminal value

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,10 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.8.2 — 2026-04-24
+
+- Fix `wait_for_geofence` reporting premature success when the vehicle's TCU is unreachable (energy-saving mode). `isCommandProcessing` flips off as soon as the server state machine is idle, but the async command to the car can still be pending with `activateAsyncCommandStatus` / `deactivateAsyncCommandStatus` in a non-terminal state. The wait loop now polls until both async-status fields reach a terminal value (`"success"`, `"failure"`, `"timeout"`, or the unset empty string) — matching the behaviour Honda's own app relies on.
+
 ## 5.8.1 — 2026-04-24
 
 - CLI `capabilities` command now lists every active capability the API reports, rendered by their raw Honda API key (e.g. `telematicsRemoteLockUnlock`, `useSpecificTemperatureControl`, `smartCharge`). Previously only 12 hardcoded capabilities were shown with translated labels; that list silently omitted the 17 fields added in 5.8.0 and the translations themselves were partly invented rather than sourced from Honda. Raw API keys are honest, identical in every locale, and forward-compatible with flags Honda adds that this library version doesn't yet know about.

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.8.1"
+version = "5.8.2"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -1225,14 +1225,26 @@ class HondaAPI:
 
     def wait_for_geofence(self, vin: str, timeout: int = 420,
                           poll_interval: float = 5.0) -> Geofence | None:
-        """Poll geofence config until processing completes, fails, or timeout."""
+        """Poll geofence config until the activate/deactivate async command
+        reaches a terminal status ("success" / "failure" / "timeout"), or
+        until the overall ``timeout`` is reached.
+
+        Honda reports the truthful outcome of a geofence save/clear in
+        ``activateAsyncCommandStatus`` / ``deactivateAsyncCommandStatus``.
+        The ``isCommandProcessing`` flag flips off as soon as the server
+        state machine is idle, even if the async command to the car is
+        still pending — relying on it reports success prematurely when
+        the TCU is unreachable (energy-saving mode) and the phone app
+        subsequently surfaces a failure we never saw.
+        """
         deadline = time.time() + timeout
+        terminal = {"", "success", "failure", "timeout"}
+        gf: Geofence | None = None
         while time.time() < deadline:
             gf = self.get_geofence(vin)
-            if gf is None or not gf.processing:
+            if gf is None:
                 return gf
-            if gf.activate_status in ("failure", "timeout") \
-               or gf.deactivate_status in ("failure", "timeout"):
+            if gf.activate_status in terminal and gf.deactivate_status in terminal:
                 return gf
             time.sleep(poll_interval)
         return gf

--- a/tests/test_geofence.py
+++ b/tests/test_geofence.py
@@ -94,3 +94,115 @@ class TestCoordinateConversion:
         gf = Geofence.from_api(data)
         assert gf.latitude == 0.0
         assert gf.longitude == 0.0
+
+
+
+class TestWaitForGeofence:
+    """Ensure wait_for_geofence polls until activate/deactivate status is terminal."""
+
+    def _build_api(self, responses):
+        """Return a HondaAPI whose get_geofence emits the given sequence of Geofence objects."""
+        import time as _time
+
+        from pymyhondaplus.api import HondaAPI
+
+        api = HondaAPI.__new__(HondaAPI)  # skip __init__ (no auth needed)
+        it = iter(responses)
+
+        def _get_geofence(_vin):
+            return next(it)
+
+        api.get_geofence = _get_geofence  # type: ignore[method-assign]
+
+        # Avoid real sleeping between polls.
+        self._sleeps = []
+
+        def _fake_sleep(seconds):
+            self._sleeps.append(seconds)
+
+        self._real_sleep = _time.sleep
+        _time.sleep = _fake_sleep  # monkey-patch module-level
+        self._time_module = _time
+        return api
+
+    def teardown_method(self):
+        # Restore real sleep.
+        if hasattr(self, "_real_sleep") and self._real_sleep is not None:
+            self._time_module.sleep = self._real_sleep
+            self._real_sleep = None
+
+    def test_returns_immediately_on_terminal_success(self):
+        gf_success = Geofence.from_api({**ACTIVE_GEOFENCE_API, "activateAsyncCommandStatus": "success"})
+        api = self._build_api([gf_success])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=1.0)
+        assert result is gf_success
+        assert self._sleeps == []  # no polling needed
+
+    def test_returns_immediately_on_terminal_failure(self):
+        gf_failure = Geofence.from_api({**ACTIVE_GEOFENCE_API, "activateAsyncCommandStatus": "failure"})
+        api = self._build_api([gf_failure])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=1.0)
+        assert result is gf_failure
+
+    def test_returns_immediately_on_terminal_timeout(self):
+        gf_timeout = Geofence.from_api({**ACTIVE_GEOFENCE_API, "activateAsyncCommandStatus": "timeout"})
+        api = self._build_api([gf_timeout])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=1.0)
+        assert result is gf_timeout
+
+    def test_polls_past_is_command_processing_until_activate_status_terminal(self):
+        """Regression: isCommandProcessing=False alone is not enough to exit."""
+        raw_processing = {
+            **ACTIVE_GEOFENCE_API,
+            "isCommandProcessing": False,  # server state machine idle
+            "activateAsyncCommandStatus": "",  # but async command still pending (empty != terminal for "processing")
+        }
+        # Empty string IS in the terminal set — simulate "still pending" via a non-empty non-terminal value.
+        raw_processing["activateAsyncCommandStatus"] = "processing"
+        gf_pending = Geofence.from_api(raw_processing)
+        gf_success = Geofence.from_api({**ACTIVE_GEOFENCE_API, "activateAsyncCommandStatus": "success"})
+        api = self._build_api([gf_pending, gf_pending, gf_success])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=2.0)
+        assert result is gf_success
+        assert self._sleeps == [2.0, 2.0]  # slept twice between polls
+
+    def test_times_out_without_terminal_status(self, monkeypatch):
+        """If deadline hits while async status still pending, return last observed state."""
+        import time as _time
+
+        raw_pending = {**ACTIVE_GEOFENCE_API, "activateAsyncCommandStatus": "processing"}
+        gf_pending = Geofence.from_api(raw_pending)
+
+        # Simulate clock advancing past the deadline after a few polls.
+        fake_now = [1000.0]
+        monkeypatch.setattr(_time, "time", lambda: fake_now[0])
+        monkeypatch.setattr(_time, "sleep", lambda s: fake_now.__setitem__(0, fake_now[0] + s))
+
+        from pymyhondaplus.api import HondaAPI
+        api = HondaAPI.__new__(HondaAPI)
+        api.get_geofence = lambda _vin: gf_pending  # type: ignore[method-assign]
+
+        try:
+            result = api.wait_for_geofence("VIN", timeout=3, poll_interval=1.0)
+        finally:
+            # pytest monkeypatch auto-restores at teardown
+            pass
+        assert result is gf_pending
+        assert result.activate_status == "processing"
+
+    def test_returns_none_when_geofence_cleared(self):
+        api = self._build_api([None])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=1.0)
+        assert result is None
+
+    def test_empty_async_status_is_terminal(self):
+        """An empty string means the command is not pending; do not keep polling."""
+        gf_empty = Geofence.from_api({
+            **ACTIVE_GEOFENCE_API,
+            "activateAsyncCommandStatus": "",
+            "deactivateAsyncCommandStatus": "",
+        })
+        api = self._build_api([gf_empty])
+        result = api.wait_for_geofence("VIN", timeout=60, poll_interval=1.0)
+        assert result is gf_empty
+        assert self._sleeps == []


### PR DESCRIPTION
## Summary

Fix \`wait_for_geofence\` reporting premature success when the vehicle's TCU is in energy-saving mode (unreachable).

## What's wrong today

Honda's geofence response has two state machines:
- \`isCommandProcessing\` — the server's command state machine is actively working.
- \`activateAsyncCommandStatus\` / \`deactivateAsyncCommandStatus\` — terminal status of the async command actually sent to the car (\`success\` / \`failure\` / \`timeout\`).

The current \`wait_for_geofence\` exits as soon as \`isCommandProcessing\` flips off. That happens as soon as the server accepts the write — the async command to the car may still be pending. If the TCU never wakes up, Honda eventually marks the async status as \`failure\` / \`timeout\`, the phone app surfaces it to the user, and we've long since claimed success.

## Fix

Wait until both \`activate_status\` and \`deactivate_status\` are in a terminal value: \`\"success\"\` / \`\"failure\"\` / \`\"timeout\"\` / \`\"\"\` (not applicable). This matches what Honda's own app uses as the authoritative signal — confirmed in the decompiled JS where \`GeoFenceCommandStatus\` enum is exactly \`{success, failure, timeout}\` and the render code branches on those values.

## Tests

7 new regression tests in \`tests/test_geofence.py\` covering:
- Immediate return on each terminal value (success / failure / timeout / empty).
- Polling past a non-terminal status until it resolves.
- Deadline fallback with a monkey-patched clock.
- Cleared geofence (\`None\` response) short-circuits.

\`pytest\` — 234 passed, \`ruff check\` clean, \`mypy\` clean.

## Release

Merge into main, tag \`5.8.2\` on main, release.