### PR TITLE
Add --local-tz flag for local-time CLI output

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,11 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.9.0 — 2026-05-22
+
+- New global flag `--local-tz` renders timestamps in human-readable CLI output (`status`, `location`, `trips`, `trip-detail`) in the system's local timezone instead of UTC. Default behavior is unchanged — UTC with `+00:00` suffix — so existing scripts and consumers are not affected. JSON and CSV output are also unchanged (raw API passthrough).
+- `trip-detail` now accepts either UTC or local-tz ISO 8601 strings for its `start_time` / `end_time` arguments and normalizes them to UTC before calling Honda's endpoint, so timestamps copied from `trips --local-tz` round-trip cleanly.
+
 ## 5.8.2 — 2026-04-25
 
 - `wait_for_geofence` now polls on `isWaitingForActivate` / `isWaitingForDeactivate` (matching Honda's own app) instead of `isCommandProcessing`. The previous logic exited as soon as the server's state machine went idle, which is well before the async command to the car has actually completed — when the TCU was unreachable (energy-saving mode), the wait reported a result based on stale `activateAsyncCommandStatus` from the *previous* command, often as immediate "failure" or "timeout". The fix tracks the actual in-flight flag, ignoring stale status until the new command resolves.

--- a/USAGE.md
+++ b/USAGE.md
@@ -267,6 +267,8 @@ pymyhondaplus trip-detail "2026-03-19T16:23:13+00:00" "2026-03-19T17:05:56+00:00
 pymyhondaplus --json trip-detail "2026-03-19T16:23:13+00:00" "2026-03-19T17:05:56+00:00"
 ```
 
+Either UTC or local-tz ISO 8601 strings are accepted — timestamps copied from `trips --local-tz` are normalized to UTC before reaching Honda's endpoint.
+
 ### Trip statistics
 
 Aggregated statistics over a period:
@@ -313,6 +315,7 @@ These must be placed **before** the subcommand:
 |--------|-------------|
 | `--vin`, `-v` | Vehicle VIN, nickname, or plate |
 | `--json` | Output raw JSON |
+| `--local-tz` | Render timestamps in local timezone instead of UTC (text output only; JSON / CSV stay UTC) |
 | `--fresh` | Request fresh data from car (wakes TCU) |
 | `--token-file PATH` | Custom token file path (or set `HONDA_TOKEN_FILE`) |
 | `--key-file PATH` | Custom device key file path (or set `HONDA_KEY_FILE`) |

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.8.2"
+version = "5.9.0"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -11,7 +11,7 @@ import os
 import sys
 import threading
 import time
-from datetime import date, datetime, timedelta
+from datetime import date, datetime, timedelta, timezone
 from pathlib import Path
 
 try:
@@ -106,6 +106,33 @@ def _to_camel_case(name: str) -> str:
     if "_" not in name:
         return name
     return "".join(p.title() for p in name.split("_"))
+
+
+def _format_ts(s, local: bool) -> str:
+    """Render an ISO-8601 UTC timestamp in local time when local=True; else pass through.
+
+    Date-only or non-ISO strings are returned unchanged. The output shape matches the
+    default UTC form (`YYYY-MM-DDTHH:MM:SS±HH:MM`) so it round-trips through `_to_utc_iso`.
+    """
+    if not local or not s or "T" not in str(s):
+        return s
+    try:
+        dt = datetime.fromisoformat(s)
+    except ValueError:
+        return s
+    return dt.astimezone().isoformat(timespec="seconds")
+
+
+def _to_utc_iso(s: str) -> str:
+    """Normalize an ISO-8601 timestamp to UTC ('+00:00') for Honda's API.
+
+    Accepts already-UTC strings or any other offset (e.g. local-tz output from `trips --local-tz`).
+    Returns the input unchanged if it can't be parsed; the API will then surface its own error.
+    """
+    try:
+        return datetime.fromisoformat(s).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+    except (ValueError, TypeError):
+        return s
 
 
 def _month_starts_for_period(start_date: date, end_date: date) -> list[str]:
@@ -273,7 +300,7 @@ def _handle_status_command(api: HondaAPI, vin: str, args: argparse.Namespace) ->
     ]
     if ev['warning_lamps']:
         rows.append((t("warnings_label"), ", ".join(ev['warning_lamps'])))
-    rows.append((t("timestamp_label"), ev['timestamp']))
+    rows.append((t("timestamp_label"), _format_ts(ev['timestamp'], args.local_tz)))
 
     # Separate labeled rows from standalone flags
     labeled = [(lbl, val) for lbl, val in rows if val is not None]
@@ -299,7 +326,7 @@ def _handle_location_command(api: HondaAPI, vin: str, args: argparse.Namespace) 
     print(f"Latitude:  {ev['latitude']:.6f}")
     print(f"Longitude: {ev['longitude']:.6f}")
     print(f"Speed:     {ev['speed']} {ev['speed_unit']}")
-    print(f"Timestamp: {gps.get('dtTime', ev['timestamp'])}")
+    print(f"Timestamp: {_format_ts(gps.get('dtTime', ev['timestamp']), args.local_tz)}")
     return 0
 
 
@@ -356,8 +383,12 @@ def _handle_charge_limit_command(api: HondaAPI, vin: str, args: argparse.Namespa
 
 def _handle_trip_detail_command(api: HondaAPI, vin: str, args: argparse.Namespace) -> int:
     """Handle the trip-detail command, preserving current CLI behavior."""
+    # Normalize positional args to UTC so users can paste either UTC or local-tz strings
+    # (the latter come from `trips --local-tz` output). Honda's endpoint expects UTC.
+    start = _to_utc_iso(args.start_time)
+    end = _to_utc_iso(args.end_time)
     try:
-        locs = api.get_trip_locations(vin, args.start_time, args.end_time)
+        locs = api.get_trip_locations(vin, start, end)
     except HondaAPIError as e:
         print(f"Failed to fetch trip detail: {e}", file=sys.stderr)
         return 1
@@ -365,10 +396,10 @@ def _handle_trip_detail_command(api: HondaAPI, vin: str, args: argparse.Namespac
         print(json.dumps(locs, indent=2))
         return 0
     print("Start:")
-    print(f"  Time:      {locs.get('start_time', 'N/A')}")
+    print(f"  Time:      {_format_ts(locs.get('start_time', 'N/A'), args.local_tz)}")
     print(f"  Location:  {locs.get('start_lat', 'N/A')}, {locs.get('start_lon', 'N/A')}")
     print("End:")
-    print(f"  Time:      {locs.get('end_time', 'N/A')}")
+    print(f"  Time:      {_format_ts(locs.get('end_time', 'N/A'), args.local_tz)}")
     print(f"  Location:  {locs.get('end_lat', 'N/A')}, {locs.get('end_lon', 'N/A')}")
     return 0
 
@@ -553,7 +584,9 @@ def _handle_trips_command(
         writer.writerows(camel_rows)
     else:
         for row in rows:
-            line = (f"  {row.get('OneTripDate', '?')}  {row.get('StartTime', '?')} -> {row.get('EndTime', '?')}  "
+            start = _format_ts(row.get('StartTime', '?'), args.local_tz)
+            end = _format_ts(row.get('EndTime', '?'), args.local_tz)
+            line = (f"  {row.get('OneTripDate', '?')}  {start} -> {end}  "
                     f"{row.get('Mileage', '?')}  {row.get('DriveTime', '?')} min  "
                     f"avg {row.get('AveSpeed', '?')}  max {row.get('MaxSpeed', '?')}  "
                     f"{row.get('AveFuelEconomy', '?')} {consumption_unit}")
@@ -737,6 +770,8 @@ vehicle selection (only needed with multiple vehicles):
     parser.add_argument("--fresh", action="store_true",
                         help="Request fresh data from car")
     parser.add_argument("--json", action="store_true", help="Output raw JSON")
+    parser.add_argument("--local-tz", action="store_true",
+                        help="Display timestamps in local timezone instead of UTC (text output only)")
     parser.add_argument("--user-info", action="store_true",
                         help="Show user info and vehicle list")
     parser.add_argument("--token-file", type=Path, default=DEFAULT_TOKEN_FILE,

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -305,3 +305,84 @@ def test__main_exits_130_on_keyboard_interrupt(monkeypatch):
         cli._main()
 
     assert exc.value.code == 130
+
+
+@pytest.mark.parametrize("value", [None, "", "2026-03-21", "not-a-timestamp"])
+def test_format_ts_passes_through_non_iso_or_empty(value):
+    assert cli._format_ts(value, True) == value
+
+
+def test_format_ts_returns_input_when_local_disabled():
+    assert cli._format_ts("2026-03-21T14:12:41+00:00", False) == "2026-03-21T14:12:41+00:00"
+
+
+def test_format_ts_converts_utc_to_local_when_enabled(monkeypatch):
+    import time as _time
+    if not hasattr(_time, "tzset"):
+        pytest.skip("time.tzset not available on this platform")
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    _time.tzset()
+    # 14:12:41 UTC on 2026-03-21 is 15:12:41 CET (winter, UTC+1).
+    assert cli._format_ts("2026-03-21T14:12:41+00:00", True) == "2026-03-21T15:12:41+01:00"
+
+
+def test_format_ts_output_roundtrips_through_to_utc_iso(monkeypatch):
+    """Local-tz output must parse cleanly back into UTC via _to_utc_iso."""
+    import time as _time
+    if not hasattr(_time, "tzset"):
+        pytest.skip("time.tzset not available on this platform")
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    _time.tzset()
+    src = "2026-03-21T14:12:41+00:00"
+    local = cli._format_ts(src, True)
+    assert cli._to_utc_iso(local) == src
+
+
+@pytest.mark.parametrize("inp, expected", [
+    ("2026-03-21T14:12:41+00:00", "2026-03-21T14:12:41+00:00"),
+    ("2026-03-21T15:12:41+01:00", "2026-03-21T14:12:41+00:00"),
+    ("2026-03-21T11:12:41-03:00", "2026-03-21T14:12:41+00:00"),
+])
+def test_to_utc_iso_normalizes_any_offset_to_utc(inp, expected):
+    assert cli._to_utc_iso(inp) == expected
+
+
+@pytest.mark.parametrize("garbage", ["", "garbage", None])
+def test_to_utc_iso_returns_input_on_unparseable(garbage):
+    assert cli._to_utc_iso(garbage) == garbage
+
+
+def test_trip_detail_normalizes_local_tz_input_to_utc(monkeypatch, capsys):
+    """trips --local-tz prints offsets like +01:00; pasting those back into trip-detail
+    must still hit Honda's endpoint with UTC strings."""
+    fake_api = _FakeAPI([
+        {"vin": "VIN123", "name": "Honda e", "plate": "", "fuel_type": "E"},
+    ], default_vin="VIN123")
+    captured = {}
+
+    def fake_get_trip_locations(vin, start_time, end_time):
+        captured["vin"] = vin
+        captured["start"] = start_time
+        captured["end"] = end_time
+        return {
+            "start_time": "2026-03-21T14:12:41+00:00",
+            "end_time": "2026-03-21T14:49:55+00:00",
+            "start_lat": 41.0, "start_lon": 12.0,
+            "end_lat": 42.0, "end_lon": 13.0,
+        }
+
+    fake_api.get_trip_locations = fake_get_trip_locations
+    _patch_common(monkeypatch, fake_api)
+    monkeypatch.setattr(cli.sys, "argv", [
+        "pymyhondaplus", "trip-detail",
+        "2026-03-21T15:12:41+01:00", "2026-03-21T15:49:55+01:00",
+    ])
+
+    rc = cli.main()
+
+    assert rc == 0
+    assert captured["start"] == "2026-03-21T14:12:41+00:00"
+    assert captured["end"] == "2026-03-21T14:49:55+00:00"
+    # Output (text mode) should still show UTC by default
+    out = capsys.readouterr().out
+    assert "2026-03-21T14:12:41+00:00" in out


### PR DESCRIPTION
Closes #9.

Adds a global `--local-tz` flag that renders timestamps in the system's local timezone in the human-readable output of `status`, `location`, `trips`, and `trip-detail`. Default behavior is unchanged — UTC with `+00:00` suffix — so existing scripts and downstream consumers are unaffected. JSON and CSV output are also unchanged (raw API passthrough).

The local-tz output uses the same ISO 8601 shape as the UTC default, only the offset differs (e.g. `2026-05-22T17:09:17+02:00`).

`trip-detail` now accepts either UTC or local-tz strings for its `start_time` / `end_time` arguments and normalizes them to UTC before calling Honda's endpoint, so timestamps copied from `trips --local-tz` round-trip cleanly. Normalization is always on, independent of the flag.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/` — 249 passed
- [x] `pymyhondaplus status` — unchanged (`+00:00`)
- [x] `pymyhondaplus --local-tz status` — shows local offset (`+02:00` for CEST)
- [x] `pymyhondaplus --local-tz trips` — all StartTime / EndTime columns shifted
- [x] Copy a `+02:00` pair from `trips --local-tz` into `pymyhondaplus trip-detail <start> <end>` — Honda returns valid coordinates (round-trip via `_to_utc_iso`)
- [x] `pymyhondaplus --json status|trips|trip-detail` byte-identical to current
