### PR TITLE
Split Car Finder from dashboard location; add find-car CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,36 @@ All notable changes to this project will be documented in this file.
 
 ## 5.9.0 — 2026-05-22
 
-- New global flag `--local-tz` renders timestamps in human-readable CLI output (`status`, `location`, `trips`, `trip-detail`) in the system's local timezone instead of UTC. Default behavior is unchanged — UTC with `+00:00` suffix — so existing scripts and consumers are not affected. JSON and CSV output are also unchanged (raw API passthrough).
+### Breaking changes
+
+- `request_dashboard_refresh(vin)` is renamed to `refresh_dashboard(vin)`. Same return type (`command_id: str`), same semantics — only the name changed.
+- `refresh_dashboard(vin, timeout, poll_interval) -> CommandResult` (the high-level convenience that fired the command and waited) is **removed**. Callers should pair the new low-level `refresh_dashboard(vin)` with `wait_for_command(command_id, ...)` to get the previous behavior.
+- `request_car_location(vin)` is renamed to `refresh_location(vin)`.
+
+### New
+
+- `CarLocation` dataclass + `CarLocation.from_command_result(result)` for extracting GPS data from a `refresh_location` command result. Honda's `/tsp/car-location` endpoint returns the location inside the async-command-status response (in `output.Content` as a JSON-encoded payload with coordinates in milliarcseconds and the *actual* GPS fix time), not by updating `/tsp/dashboard-latest`. This parser handles the unwrapping, MAS→decimal conversion, and the `kph`→`km/h` unit normalization. The fix time it reports is truthful — when the TCU actually acquired the GPS — whereas the dashboard's `gpsData.dtTime` is stamped with the server's response time on every refresh and doesn't represent when the car was actually located.
+- New CLI command `find-car`: the dedicated Car Finder query. Calls `/tsp/car-location` and prints the TCU's last GPS fix with its truthful fix-time, course heading, and ignition state. The reported coordinates may differ from `location` (which is dashboard-derived) — TCU-side GPS may be drifted at parking, while dashboard refresh tends to surface a more spatially accurate position. The two are different concepts and we expose them as different commands.
+- `location --fresh` now refreshes the dashboard (consistent with `status --fresh`); previously it routed to `/tsp/car-location`. For Car Finder behaviour, use `find-car`.
+- Global flag `--local-tz` renders timestamps in human-readable CLI output (`status`, `location`, `trips`, `trip-detail`, `find-car`) in the system's local timezone instead of UTC. Default behavior is unchanged — UTC with `+00:00` suffix — so existing scripts and consumers are not affected. JSON and CSV output are also unchanged (raw API passthrough).
 - `trip-detail` now accepts either UTC or local-tz ISO 8601 strings for its `start_time` / `end_time` arguments and normalizes them to UTC before calling Honda's endpoint, so timestamps copied from `trips --local-tz` round-trip cleanly.
+
+Migration:
+
+```python
+# Before
+result = api.refresh_dashboard(vin, timeout=90)
+# After
+command_id = api.refresh_dashboard(vin)
+result = api.wait_for_command(command_id, timeout=90)
+
+# Before
+command_id = api.request_car_location(vin)
+# After
+command_id = api.refresh_location(vin)
+```
+
+The single-tier API matches how every other action method (`remote_lock`, `set_climate_settings`, etc.) already behaves: send the command, get a `command_id`, optionally wait via `wait_for_command`.
 
 ## 5.8.2 — 2026-04-25
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ pymyhondaplus profile                   # account name, email, address
 
 # Vehicle status
 pymyhondaplus status
-pymyhondaplus status --fresh            # wake TCU for fresh data
+pymyhondaplus --fresh status            # wake TCU for fresh data
 pymyhondaplus status --watch 5m         # poll and print changes
 
 # Geofence

--- a/USAGE.md
+++ b/USAGE.md
@@ -100,7 +100,7 @@ pymyhondaplus geofence-clear
 pymyhondaplus status
 
 # Request fresh data from car (wakes the TCU)
-pymyhondaplus status --fresh
+pymyhondaplus --fresh status
 
 # Output as JSON
 pymyhondaplus --json status
@@ -139,15 +139,29 @@ Press Ctrl+C to stop.
 ## Location
 
 ```bash
-# Get last known location
+# Get last known location (dashboard-cached)
 pymyhondaplus location
 
-# Request fresh location from car (wakes TCU)
-pymyhondaplus location --fresh
+# Refresh the dashboard first (matches `--fresh status`)
+pymyhondaplus --fresh location
 
 # Output as JSON
 pymyhondaplus --json location
 ```
+
+`location` reads the dashboard's `gpsData`. Coordinates are server-side cached and typically spatially accurate, but the `dtTime` field is the server response time, not when the TCU actually got the fix. For the truthful fix-time from the TCU itself, use `find-car`.
+
+## Find car
+
+```bash
+# Wake the TCU and request a fresh GPS fix (Car Finder)
+pymyhondaplus find-car
+
+# Output as JSON
+pymyhondaplus --json find-car
+```
+
+Calls Honda's `/tsp/car-location` endpoint — the same one the official app's Car Finder uses. Returns coordinates, speed, heading, ignition state, and the **actual** moment the TCU acquired the fix. Slower than `location` (~30–90s, wakes a sleeping car, costs one command-quota slot), and the reported position can drift from the parked-spot reality when GPS reception is poor. The fix-time, however, is truthful — unlike the dashboard's `dtTime`, which is regenerated on every poll.
 
 ## Remote commands
 

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -5,6 +5,7 @@ Tested on Honda e. Should work with other Honda Connect Europe vehicles
 (e:Ny1, ZR-V, CR-V, Civic, HR-V, Jazz 2020+) but these are untested.
 """
 
+import json
 import os
 import time
 import logging
@@ -215,6 +216,62 @@ class CommandResult:
     @property
     def success(self) -> bool:
         return self.complete and self.status == "success" and not self.timed_out
+
+
+@dataclass
+class CarLocation:
+    """Fresh car location from a ``/tsp/car-location`` command result.
+
+    The endpoint wakes the TCU and returns the location *only* via the
+    async-command-status response — it does not update
+    ``/tsp/dashboard-latest``. Use :meth:`from_command_result` to extract
+    typed location data from a :meth:`HondaAPI.wait_for_command` result.
+    """
+    latitude: float = 0.0
+    longitude: float = 0.0
+    timestamp: str = ""
+    speed: float = 0.0
+    speed_unit: str = "km/h"
+    course_heading: float = 0.0
+    ignition: str = ""
+
+    @classmethod
+    def from_command_result(cls, result: CommandResult) -> "CarLocation | None":
+        output = (result.raw or {}).get("output") or {}
+        content = output.get("Content")
+        if content is None:
+            return None
+        try:
+            data = json.loads(content) if isinstance(content, str) else content
+        except (json.JSONDecodeError, TypeError):
+            return None
+        gps = (data or {}).get("gpsData") or {}
+        coord = gps.get("coordinate") or {}
+        velocity = gps.get("velocity") or {}
+        # Coordinates from this endpoint come as integer milliarcseconds.
+        unit_raw = velocity.get("unit", "kph")
+        # Normalize ignition: API returns "ignitionOn" / "ignitionOff" here,
+        # but the dashboard's igStatus field uses "ON" / "OFF". Collapse to a
+        # canonical lowercase "on" / "off" so downstream display logic can
+        # translate via existing keys.
+        ignition_raw = str(data.get("ignition", "")).lower()
+        if ignition_raw.endswith("on"):
+            ignition = "on"
+        elif ignition_raw.endswith("off"):
+            ignition = "off"
+        elif ignition_raw:
+            ignition = ignition_raw
+        else:
+            ignition = "unknown"
+        return cls(
+            latitude=float(coord.get("latitude", 0)) / 3_600_000,
+            longitude=float(coord.get("longitude", 0)) / 3_600_000,
+            timestamp=gps.get("dtTime", ""),
+            speed=float(velocity.get("value", 0)),
+            speed_unit="km/h" if unit_raw == "kph" else unit_raw,
+            course_heading=float(gps.get("courseHeading", 0)),
+            ignition=ignition,
+        )
 
 
 class VehicleCapabilities:
@@ -874,10 +931,12 @@ class HondaAPI:
             raise HondaAPIError(resp.status_code, resp.text)
         return resp.json()
 
-    def request_dashboard_refresh(self, vin: str) -> str:
-        """
-        Request fresh data from the car (wakes up the TCU).
-        Returns the async command ID to poll with poll_command().
+    def refresh_dashboard(self, vin: str) -> str:
+        """Request fresh dashboard data from the car (wakes the TCU).
+
+        Returns the async command ID. Pair with ``wait_for_command(id)`` to
+        block until the TCU responds. ``/tsp/dashboard`` refreshes EV/charge/
+        climate but **not** GPS — for fresh GPS use :meth:`refresh_location`.
         """
         resp = self._request("POST", f"/tsp/dashboard?vin={vin}")
         if resp.status_code not in (200, 202):
@@ -932,29 +991,23 @@ class HondaAPI:
         if not fresh:
             return self.get_dashboard_cached(vin, language)
 
-        result = self.refresh_dashboard(vin, timeout, poll_interval)
+        command_id = self.refresh_dashboard(vin)
+        result = self.wait_for_command(command_id, timeout, poll_interval)
         if not result.success:
             logger.debug("Dashboard refresh did not succeed (status=%s), using cached data",
                          result.status)
 
         return self.get_dashboard_cached(vin, language)
 
-    def refresh_dashboard(self, vin: str, timeout: int = 90,
-                          poll_interval: float = 1.5) -> CommandResult:
-        """Request fresh data from car and wait for completion.
-
-        Returns the CommandResult (check .success to see if the car responded).
-        """
-        command_id = self.request_dashboard_refresh(vin)
-        if not command_id:
-            logger.warning("No command ID returned")
-            return CommandResult(complete=False, status="no_command_id")
-        return self.wait_for_command(command_id, timeout, poll_interval)
-
     # -- Location --
 
-    def request_car_location(self, vin: str) -> str:
-        """Request fresh car location (async, wakes TCU). Returns command ID."""
+    def refresh_location(self, vin: str) -> str:
+        """Request fresh GPS from the car (wakes the TCU).
+
+        Returns the async command ID. Pair with ``wait_for_command(id)`` to
+        block until the TCU responds. ``/tsp/car-location`` is the only path
+        Honda exposes that refreshes GPS — ``/tsp/dashboard`` does not.
+        """
         return self._remote_command("car-location", vin)
 
     # -- Remote commands --

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -19,7 +19,15 @@ try:
 except ImportError:
     argcomplete = None  # type: ignore[assignment]
 
-from .api import DEFAULT_TOKEN_FILE, HondaAPI, HondaAPIError, HondaAuthError, compute_trip_stats, parse_ev_status
+from .api import (
+    DEFAULT_TOKEN_FILE,
+    CarLocation,
+    HondaAPI,
+    HondaAPIError,
+    HondaAuthError,
+    compute_trip_stats,
+    parse_ev_status,
+)
 from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth
 from .http import DEFAULT_REQUEST_TIMEOUT
 from .storage import get_storage
@@ -219,21 +227,27 @@ def _get_dashboard(api: HondaAPI, vin: str, fresh: bool, json_mode: bool = False
         return api.get_dashboard(vin)
 
     with _Spinner(get_translator()("cmd_refreshing")):
-        result = api.refresh_dashboard(vin)
+        command_id = api.refresh_dashboard(vin)
+        result = api.wait_for_command(command_id, timeout=90)
     dashboard = api.get_dashboard_cached(vin)
 
     if not result.success and not json_mode:
-        ts = dashboard.get("timestamp", "unknown")
-        if result.timed_out:
-            print(f"Refresh failed: car did not respond. Showing cached data from {ts}.",
-                  file=sys.stderr)
-        else:
-            reason = result.reason or result.status
-            print(f"Refresh failed ({reason}). Showing cached data from {ts}.",
-                  file=sys.stderr)
-        print(file=sys.stderr)
+        _print_refresh_failed(dashboard, result)
 
     return dashboard
+
+
+def _print_refresh_failed(dashboard: dict, result) -> None:
+    """Print a user-facing message when a fresh-data refresh did not succeed."""
+    ts = dashboard.get("timestamp", "unknown")
+    if result.timed_out:
+        print(f"Refresh failed: car did not respond. Showing cached data from {ts}.",
+              file=sys.stderr)
+    else:
+        reason = result.reason or result.status
+        print(f"Refresh failed ({reason}). Showing cached data from {ts}.",
+              file=sys.stderr)
+    print(file=sys.stderr)
 
 
 def _handle_status_command(api: HondaAPI, vin: str, args: argparse.Namespace) -> int:
@@ -315,7 +329,13 @@ def _handle_status_command(api: HondaAPI, vin: str, args: argparse.Namespace) ->
 
 
 def _handle_location_command(api: HondaAPI, vin: str, args: argparse.Namespace) -> int:
-    """Handle the location command, preserving current CLI behavior."""
+    """Handle the location command.
+
+    Reads the dashboard's ``gpsData`` (cached, or freshly refreshed via
+    ``--fresh``). For the official-app's Car Finder behaviour (last GPS
+    fix the TCU recorded, with truthful fix-time), use the ``find-car``
+    command instead.
+    """
     dashboard = _get_dashboard(api, vin, fresh=args.fresh, json_mode=args.json)
     gps = dashboard.get("gpsData", {})
     if args.json:
@@ -327,6 +347,52 @@ def _handle_location_command(api: HondaAPI, vin: str, args: argparse.Namespace) 
     print(f"Longitude: {ev['longitude']:.6f}")
     print(f"Speed:     {ev['speed']} {ev['speed_unit']}")
     print(f"Timestamp: {_format_ts(gps.get('dtTime', ev['timestamp']), args.local_tz)}")
+    return 0
+
+
+def _handle_find_car_command(api: HondaAPI, vin: str, args: argparse.Namespace) -> int:
+    """Handle the find-car command.
+
+    Calls Honda's ``/tsp/car-location`` endpoint (the same one the official
+    app's Car Finder uses) and reports the TCU's last GPS fix with its
+    actual fix-time. The position can differ from the dashboard's
+    location: car-location is the last fix the TCU itself recorded, which
+    may be tens of metres from the parked-spot reality (degraded GPS at
+    parking, indoor reception, etc.). The fix-time, however, is truthful.
+    """
+    with _Spinner(get_translator()("cmd_refreshing")):
+        command_id = api.refresh_location(vin)
+        result = api.wait_for_command(command_id, timeout=90)
+    if not result.success:
+        if result.timed_out:
+            print("Car Finder: car did not respond.", file=sys.stderr)
+        else:
+            print(
+                f"Car Finder failed: {result.reason or result.status}",
+                file=sys.stderr,
+            )
+        return 1
+    loc = CarLocation.from_command_result(result)
+    if loc is None:
+        print("Car Finder: no GPS payload in response.", file=sys.stderr)
+        return 1
+    if args.json:
+        print(json.dumps({
+            "latitude": loc.latitude,
+            "longitude": loc.longitude,
+            "dtTime": loc.timestamp,
+            "speed": loc.speed,
+            "speed_unit": loc.speed_unit,
+            "courseHeading": loc.course_heading,
+            "ignition": loc.ignition,
+        }, indent=2))
+        return 0
+    print(f"Latitude:  {loc.latitude:.6f}")
+    print(f"Longitude: {loc.longitude:.6f}")
+    print(f"Speed:     {loc.speed} {loc.speed_unit}")
+    print(f"Heading:   {loc.course_heading}")
+    print(f"Ignition:  {loc.ignition}")
+    print(f"Timestamp: {_format_ts(loc.timestamp, args.local_tz)}")
     return 0
 
 
@@ -817,7 +883,9 @@ vehicle selection (only needed with multiple vehicles):
     status_parser = subparsers.add_parser("status", parents=[_common], help="Get vehicle status")
     status_parser.add_argument("--watch", metavar="INTERVAL",
                                 help="Poll at interval (e.g. 5m, 30s, 120). Prints only changes.")
-    subparsers.add_parser("location", parents=[_common], help="Get car GPS location")
+    subparsers.add_parser("location", parents=[_common], help="Get car GPS location (from dashboard data)")
+    subparsers.add_parser("find-car", parents=[_common],
+                          help="Get car finder location (last GPS fix recorded by the TCU, with fix-time)")
 
     _yes = argparse.ArgumentParser(add_help=False)
     _yes.add_argument("--yes", "-y", action="store_true", help="Skip confirmation prompt")
@@ -1216,6 +1284,8 @@ def _run_main(args: argparse.Namespace, storage) -> int:
 
     elif args.command == "location":
         return _handle_location_command(api, vin, args)
+    elif args.command == "find-car":
+        return _handle_find_car_command(api, vin, args)
 
     elif args.command == "lock":
         return _wait_command(api, args.timeout, api.remote_lock(vin), t("cmd_lock"))

--- a/tests/test_car_location.py
+++ b/tests/test_car_location.py
@@ -1,0 +1,88 @@
+"""Tests for CarLocation parsing from car-location command results."""
+
+import json
+
+from pymyhondaplus.api import CarLocation, CommandResult
+
+
+def _make_result(content: dict | str | None, request_status: str = "success") -> CommandResult:
+    """Build a CommandResult mirroring async-command-status JSON for tests."""
+    output = {"RequestStatus": request_status}
+    if content is not None:
+        output["Content"] = (
+            content if isinstance(content, str) else json.dumps(content)
+        )
+    return CommandResult(
+        complete=True,
+        status=request_status,
+        raw={"output": output, "isWaitingForResult": False},
+    )
+
+
+def test_parses_real_response_shape():
+    """Real shape captured from /tsp/car-location → async-command-status."""
+    result = _make_result({
+        "gpsData": {
+            "dtTime": "2026-04-26T18:18:01+00:00",
+            "coordinate": {
+                "datum": "wgs84", "format": "mas",
+                "latitude": 156791051, "longitude": 37196051,
+            },
+            "courseHeading": 293.9,
+            "accuracy": {"pdop": 2, "hdop": 2},
+            "velocity": {"unit": "kph", "value": 0},
+        },
+        "ignition": "ignitionOff",
+    })
+
+    loc = CarLocation.from_command_result(result)
+
+    assert loc is not None
+    # MAS / 3,600,000 → decimal degrees
+    assert abs(loc.latitude - 43.553) < 0.001
+    assert abs(loc.longitude - 10.332) < 0.001
+    assert loc.timestamp == "2026-04-26T18:18:01+00:00"
+    assert loc.speed == 0
+    assert loc.speed_unit == "km/h"  # kph normalized
+    assert loc.course_heading == 293.9
+    assert loc.ignition == "off"
+
+
+def test_returns_none_on_missing_content():
+    result = _make_result(None)
+    assert CarLocation.from_command_result(result) is None
+
+
+def test_returns_none_on_invalid_json():
+    result = _make_result("{not valid json")
+    assert CarLocation.from_command_result(result) is None
+
+
+def test_handles_missing_gps_data():
+    """Server may return success with empty Content; don't crash."""
+    result = _make_result({"ignition": "ignitionOff"})
+    loc = CarLocation.from_command_result(result)
+    assert loc is not None
+    assert loc.latitude == 0.0
+    assert loc.longitude == 0.0
+    assert loc.ignition == "off"
+
+
+def test_handles_pre_parsed_content():
+    """Some callers may pre-parse Content into a dict."""
+    result = CommandResult(
+        complete=True,
+        status="success",
+        raw={"output": {"Content": {
+            "gpsData": {
+                "dtTime": "2026-04-26T12:00:00+00:00",
+                "coordinate": {"latitude": 0, "longitude": 0},
+                "velocity": {"value": 5.0, "unit": "kph"},
+            },
+            "ignition": "ignitionOn",
+        }}},
+    )
+    loc = CarLocation.from_command_result(result)
+    assert loc is not None
+    assert loc.speed == 5.0
+    assert loc.ignition == "on"

--- a/tests/test_cli_behavior.py
+++ b/tests/test_cli_behavior.py
@@ -23,8 +23,10 @@ class _FakeAPI:
     def __init__(self, vehicles, default_vin=""):
         self.tokens = _FakeTokens(vehicles, default_vin=default_vin)
         self.remote_lock_called = False
+        self.refresh_location_called = False
+        self.refresh_dashboard_called = False
 
-    def get_dashboard(self, vin: str, fresh: bool = False):
+    def _dashboard_payload(self):
         return {
             "gpsData": {
                 "coordinate": {"latitude": "41,53,24.904", "longitude": "12,29,32.543"},
@@ -32,6 +34,20 @@ class _FakeAPI:
                 "velocity": {"value": "0.0", "unit": "km/h"},
             }
         }
+
+    def get_dashboard(self, vin: str, fresh: bool = False):
+        return self._dashboard_payload()
+
+    def get_dashboard_cached(self, vin: str, language: str = "it"):
+        return self._dashboard_payload()
+
+    def refresh_location(self, vin: str):
+        self.refresh_location_called = True
+        return "loc-cmd-1"
+
+    def refresh_dashboard(self, vin: str):
+        self.refresh_dashboard_called = True
+        return "dash-cmd-1"
 
     def remote_lock(self, vin: str):
         self.remote_lock_called = True
@@ -44,12 +60,32 @@ class _FakeAPI:
         return "cmd-2"
 
     def wait_for_command(self, cmd_id: str, timeout: int = 60):
+        import json as _json
+
         class _Result:
             success = True
             complete = True
             status = "success"
             timed_out = False
             reason = None
+            raw = {
+                "output": {
+                    "RequestStatus": "success",
+                    "Content": _json.dumps({
+                        "gpsData": {
+                            "dtTime": "2026-04-26T18:18:01+00:00",
+                            "coordinate": {
+                                "datum": "wgs84", "format": "mas",
+                                "latitude": 156791051,
+                                "longitude": 37196051,
+                            },
+                            "courseHeading": 293.9,
+                            "velocity": {"unit": "kph", "value": 0},
+                        },
+                        "ignition": "ignitionOff",
+                    }),
+                },
+            }
 
         return _Result()
 
@@ -108,6 +144,64 @@ def test_location_json_outputs_raw_gps_payload(monkeypatch, capsys):
     assert '"coordinate": {' in out.out
     assert '"latitude": "41,53,24.904"' in out.out
     assert '"dtTime": "2026-03-24T22:53:01+00:00"' in out.out
+
+
+def test_location_fresh_uses_dashboard_refresh(monkeypatch, capsys):
+    """`location --fresh` is a dashboard refresh now; car-location is `find-car`."""
+    fake_api = _FakeAPI([
+        {"vin": "VIN123", "name": "Honda e", "plate": "", "fuel_type": "E"},
+    ], default_vin="VIN123")
+    _patch_common(monkeypatch, fake_api)
+    monkeypatch.setattr(cli.sys, "argv", ["pymyhondaplus", "--fresh", "location"])
+
+    rc = cli.main()
+
+    assert rc == 0
+    assert fake_api.refresh_dashboard_called is True
+    assert fake_api.refresh_location_called is False
+
+
+def test_find_car_calls_car_location_endpoint(monkeypatch, capsys):
+    """`find-car` is the dedicated Car Finder command; hits /tsp/car-location."""
+    fake_api = _FakeAPI([
+        {"vin": "VIN123", "name": "Honda e", "plate": "", "fuel_type": "E"},
+    ], default_vin="VIN123")
+    _patch_common(monkeypatch, fake_api)
+    monkeypatch.setattr(cli.sys, "argv", ["pymyhondaplus", "find-car"])
+
+    rc = cli.main()
+
+    out = capsys.readouterr()
+    assert rc == 0
+    assert fake_api.refresh_location_called is True
+    assert fake_api.refresh_dashboard_called is False
+    assert "Latitude:" in out.out
+    assert "Timestamp:" in out.out
+    # Default: UTC suffix preserved
+    assert "2026-04-26T18:18:01+00:00" in out.out
+
+
+def test_find_car_local_tz_shifts_timestamp(monkeypatch, capsys):
+    """`--local-tz find-car` renders the TCU fix time in local timezone."""
+    import time as _time
+    if not hasattr(_time, "tzset"):
+        pytest.skip("time.tzset not available on this platform")
+    monkeypatch.setenv("TZ", "Europe/Rome")
+    _time.tzset()
+
+    fake_api = _FakeAPI([
+        {"vin": "VIN123", "name": "Honda e", "plate": "", "fuel_type": "E"},
+    ], default_vin="VIN123")
+    _patch_common(monkeypatch, fake_api)
+    monkeypatch.setattr(cli.sys, "argv", ["pymyhondaplus", "--local-tz", "find-car"])
+
+    rc = cli.main()
+
+    out = capsys.readouterr().out
+    assert rc == 0
+    # 2026-04-26 is past DST switch → Europe/Rome is UTC+2 (CEST).
+    assert "2026-04-26T20:18:01+02:00" in out
+    assert "+00:00" not in out  # raw UTC must not leak through
 
 
 def test_status_json_outputs_raw_dashboard(monkeypatch, capsys):


### PR DESCRIPTION
## Summary

Splits Honda's two location surfaces into distinct commands and parses the Car Finder response that was previously discarded.

- `/tsp/car-location` (Car Finder, TCU GPS) now has its own command — `find-car` — and a `CarLocation` dataclass that unwraps the nested response payload (MAS → decimal, kph → km/h, surfaces the **actual** TCU fix-time).
- `/tsp/dashboard-latest` keeps the `location` command. `location --fresh` now means "refresh the dashboard" (matches `status --fresh`); previously it routed to Car Finder.

The two surfaces have opposite trade-offs: dashboard `location` is fast, server-cached, spatially trustworthy, but its `dtTime` is the server response time (regenerated on every poll, not when the car was actually located). Car Finder `find-car` is slow (~30–90s, wakes the TCU, costs a command-quota slot), the position can drift when GPS reception is poor, but the timestamp is truthful.

## Breaking changes

- `request_car_location(vin)` → `refresh_location(vin)`
- `request_dashboard_refresh(vin)` → `refresh_dashboard(vin)` (low-level only — the high-level fire-and-wait helper was removed; pair with `wait_for_command`)

Migration block included in CHANGELOG.

## Other

- `find-car` respects the existing `--local-tz` global flag for its `Timestamp:` line.
- Doc fix: README and USAGE had examples like `pymyhondaplus status --fresh` — argparse requires global flags before the subcommand, so corrected to `pymyhondaplus --fresh status`.

## Test plan

- [x] `ruff check src/ tests/` clean
- [x] `pytest tests/` — 257 passed (was 242 before merging main's 5.9.0 local-tz changes)
- [x] Manual: `find-car` against a real car (returns fix + truthful timestamp)
- [x] Manual: `--local-tz find-car` (timestamp shifted to system tz)
- [x] Manual: `--fresh location` (now fast, matches `--fresh status`; does NOT wake TCU via Car Finder)
- [ ] Manual: `find-car` vs `--fresh location` produce comparable coords but distinct timestamps
