### PR TITLE
Stop leaking email and Honda payloads in auth INFO logs

### DIFF
--- a/src/pymyhondaplus/auth.py
+++ b/src/pymyhondaplus/auth.py
@@ -22,6 +22,15 @@ from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
 
 logger = logging.getLogger(__name__)
 
+def _redact_email(email: str) -> str:
+    """Mask an email for logging: "alice@example.com" -> "a***@example.com"."""
+    if not email or "@" not in email:
+        return "<unknown>"
+    local, _, domain = email.partition("@")
+    return f"{local[:1]}***@{domain}"
+
+
+
 API_BASE = "https://mobile-api.connected.honda-eu.com"
 
 # Server RSA public key (hardcoded in the app)
@@ -330,7 +339,7 @@ class HondaAuth:
         Complete login flow. If device is not registered, handles registration
         and email verification interactively (CLI only).
         """
-        logger.info("Starting login for %s", email)
+        logger.info("Starting login for %s", _redact_email(email))
 
         try:
             result = self.initiate_login(email, password, locale=locale)
@@ -361,7 +370,8 @@ class HondaAuth:
         try:
             reset_result = self.reset_device_authenticator(
                 email, password)
-            logger.info("reset-device-authenticator response: %s", reset_result)
+            logger.info("reset-device-authenticator: verification email requested")
+            logger.debug("reset-device-authenticator response payload: %r", reset_result)
             print("Verification email sent!")
         except HondaAuthError as e:
             if "currently blocked" in str(e):
@@ -383,7 +393,8 @@ class HondaAuth:
             raise HondaAuthError(0, f"Could not extract key from link: {link}")
 
         result = self.verify_magic_link(key, link_type)
-        logger.info("Magic link verification result: %s", result)
+        logger.info("Magic link verified")
+        logger.debug("Magic link verification result payload: %r", result)
 
         result = self.initiate_login(email, password, locale=locale)
         transaction_id = result["transactionId"]


### PR DESCRIPTION
## Summary

Three INFO-level log lines in `auth.py` were leaking personal data into anything that captures the default log level:

- `Starting login for %s` printed the user's email verbatim. Now masked via a tiny `_redact_email` helper (`alice@example.com` → `a***@example.com`).
- `reset-device-authenticator response: %s` printed the full Honda response. Split into a sanitised INFO line (`reset-device-authenticator: verification email requested`) and a DEBUG dump for diagnostic mode only.
- `Magic link verification result: %s` printed the full verify-magic-link payload at INFO; that payload can carry tokens. Same split: INFO is just `Magic link verified` now, the payload is DEBUG.

No public API change. Consumers running at the default INFO level still see the same events, just without the sensitive bits.

## Test plan

- [x] Existing test suite passes (257 tests, ruff clean).
- [ ] When merging, consider following up with a wider audit (e.g. VIN appearing in URL query strings logged via `requests` debug, etc.) — out of scope for this PR.