### PR TITLE
fix(storage): rename undecryptable files instead of deleting them

### DIFF
--- a/src/pymyhondaplus/storage.py
+++ b/src/pymyhondaplus/storage.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import platform
+import time
 from abc import ABC, abstractmethod
 from pathlib import Path
 
@@ -30,6 +31,24 @@ def _write_secure(path: Path, data: bytes | str):
 
 def _is_encrypted_format(data: dict) -> bool:
     return data.get("v") == ENCRYPTED_FORMAT_VERSION and "enc" in data
+
+
+def _move_aside_as_broken(path: Path) -> Path:
+    """Rename `path` to `<name>.broken-<unix-ts>` and return the new path.
+
+    Used when an encrypted file cannot be decrypted: we keep the ciphertext
+    instead of deleting it so the user (or a support session) can still
+    recover it if the original key is found later. Collisions in the same
+    second get a numeric suffix.
+    """
+    ts = int(time.time())
+    candidate = path.with_name(path.name + f".broken-{ts}")
+    counter = 0
+    while candidate.exists():
+        counter += 1
+        candidate = path.with_name(path.name + f".broken-{ts}-{counter}")
+    path.rename(candidate)
+    return candidate
 
 
 class SecretStorage(ABC):
@@ -130,11 +149,13 @@ class _FernetStorage(SecretStorage):
             try:
                 return self._decrypt(data["data"].encode())
             except InvalidToken:
+                broken = _move_aside_as_broken(path)
                 logger.warning(
                     "Cannot decrypt %s (encryption key changed). "
-                    "Removing stale file — please login again.", path
+                    "Moved aside as %s so the ciphertext is preserved; "
+                    "please login again.",
+                    path, broken.name,
                 )
-                path.unlink()
                 return None
 
         # Plain-text token format — migrate

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -121,10 +121,11 @@ class TestEncryptedFileStorage:
         raw = json.loads(encrypted_storage.token_file.read_text())
         assert raw["v"] == 2
 
-    def test_wrong_key_removes_file(self, tmp_path):
-        """If encryption key changes, stale file is removed."""
+    def test_wrong_key_moves_file_aside(self, tmp_path):
+        """If the encryption key changes, the file is renamed instead of deleted."""
         s1 = EncryptedFileStorage(tmp_path / "tokens.json", tmp_path / "key.pem")
         s1.save_tokens(SAMPLE_TOKENS)
+        original_ciphertext = s1.token_file.read_text()
 
         # Change the salt to simulate a different machine
         s1._salt_file.write_bytes(b"x" * 32)
@@ -132,6 +133,31 @@ class TestEncryptedFileStorage:
         loaded = s1.load_tokens()
         assert loaded is None
         assert not s1.token_file.exists()
+        broken = list(tmp_path.glob("tokens.json.broken-*"))
+        assert len(broken) == 1
+        assert broken[0].read_text() == original_ciphertext
+
+    def test_wrong_key_collision_within_same_second(self, tmp_path):
+        """Two corrupted decrypts within the same second don't clobber each other."""
+        from unittest.mock import patch
+
+        s1 = EncryptedFileStorage(tmp_path / "tokens.json", tmp_path / "key.pem")
+        s1.save_tokens(SAMPLE_TOKENS)
+        s1._salt_file.write_bytes(b"x" * 32)
+
+        with patch("pymyhondaplus.storage.time.time", return_value=1700000000):
+            s1.load_tokens()
+            # Second corruption with a fresh ciphertext under the same fake clock
+            s1._salt_file.write_bytes(b"y" * 32)
+            s1.save_tokens(SAMPLE_TOKENS)
+            s1._salt_file.write_bytes(b"z" * 32)
+            s1.load_tokens()
+
+        broken = sorted(p.name for p in tmp_path.glob("tokens.json.broken-*"))
+        assert broken == [
+            "tokens.json.broken-1700000000",
+            "tokens.json.broken-1700000000-1",
+        ]
 
 
 class TestGetStorage:


### PR DESCRIPTION
## Summary

When the encrypted token file cannot be decrypted (e.g. the Fernet key
changed because the user moved between a PyInstaller bundle and a dev
install, or the OS keyring was wiped), the library currently calls
`path.unlink()` on the file. The ciphertext is lost forever and the
user is forced to log in again with no diagnostic trail.

This change renames the file to a `.broken-<unix-ts>` sibling instead
of deleting it. Behavior is otherwise unchanged: `load_tokens()` still
returns `None` so the caller re-runs the login flow. The log line now
points at the preserved file by name.

Collisions in the same second get a numeric suffix
(`.broken-<ts>-1`, `.broken-<ts>-2`, ...).

## Test plan

- [x] `pytest` (258 tests, including the two new ones in
      `tests/test_storage.py`)
- [x] `ruff check src/ tests/`
- [x] `mypy src/`
- [x] Manual smoke test: corrupt the salt of a throwaway
      `EncryptedFileStorage`, call `load_tokens()`, confirm original
      file is gone, sibling `.broken-<ts>` file holds the original
      ciphertext, warning log mentions both paths.
