### PR TITLE
chore(release): 5.9.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.9.1 — 2026-05-24
+
+### Fixed
+
+- Encrypted storage no longer deletes token / device-key files it cannot decrypt (for example after the encryption key changes). The file is renamed aside as `<name>.broken-<timestamp>`, so the ciphertext is preserved and the next login can recover instead of starting from a silent data loss.
+- Authentication no longer logs the account email or Honda response payloads at INFO level, so credentials and personal data no longer leak into logs.
+
+### Changed
+
+- Log levels tidied up: anomalies are raised from DEBUG to WARNING, and storage backend selection plus the plaintext-to-encrypted migration are surfaced at INFO.
+
 ## 5.9.0 — 2026-05-22
 
 ### Breaking changes

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.9.0"
+version = "5.9.1"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"


### PR DESCRIPTION
Release 5.9.1. Bundles the fixes that have landed on main since 5.9.0:

- **Storage safety**: undecryptable token / device-key files are renamed aside as `<name>.broken-<timestamp>` instead of deleted, so the ciphertext is preserved and the next login can recover.
- **Log privacy**: authentication no longer logs the account email or Honda response payloads at INFO.
- **Log levels**: anomalies raised to WARNING; storage backend selection and the plaintext-to-encrypted migration surfaced at INFO.

No API changes. CHANGELOG updated; version bumped 5.9.0 to 5.9.1.
