### PR TITLE
fix: normalize UK unit aliases and locale-aware consumption_unit

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,19 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.10.0 (2026-05-30)
+
+### Added
+
+- `consumption_unit_for(fuel_type, distance_unit)`: canonical mapping shared by the library and the CLI.
+
+### Fixed
+
+- `parse_ev_status` canonicalizes the distance and speed unit strings Honda returns for non-metric accounts. UK accounts come back with `rangeUnit="mile"` (singular) and `velocity.unit="mile/h"`; the library was passing those through unchanged, breaking consumers that expect `"miles"` / `"miles/h"` (most visibly: the Home Assistant integration mislabelled odometer, range, and speed as km).
+- `compute_trip_stats` derives `consumption_unit` from `(fuel_type, distance_unit)` instead of `fuel_type` alone. UK ICE accounts now get `mpg`, UK EV accounts get `mi/kWh`. Metric accounts are unchanged.
+- `compute_trip_stats` aggregates `AveFuelEconomy` correctly for imperial units. `mpg` and `mi/kWh` are distance-per-fuel: the right rollup is `total_distance / sum(distance / efficiency)`, not the distance-weighted average used for `L/100km` / `kWh/100km`. Two trips of 10mi at 10mpg and 20mi at 20mpg now report 15.0 mpg instead of 16.7.
+- `pymyhondaplus trips` and `pymyhondaplus trip-stats` label output by the vehicle's locale: distance unit is read from the cached dashboard and the consumption label follows.
+
 ## 5.9.1 (2026-05-24)
 
 ### Fixed

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.9.1"
+version = "5.10.0"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/src/pymyhondaplus/__init__.py
+++ b/src/pymyhondaplus/__init__.py
@@ -1,6 +1,6 @@
 """Unofficial Honda Connect Europe (My Honda+) API client library."""
 
-from .api import AuthTokens, CommandResult, EVStatus, Geofence, HondaAPI, HondaAPIError, HondaAuthError, SubscriptionService, Subscription, UIConfiguration, UserProfile, Vehicle, VehicleCapabilities, compute_trip_stats, parse_charge_schedule, parse_climate_schedule, parse_ev_status
+from .api import AuthTokens, CommandResult, EVStatus, Geofence, HondaAPI, HondaAPIError, HondaAuthError, SubscriptionService, Subscription, UIConfiguration, UserProfile, Vehicle, VehicleCapabilities, compute_trip_stats, consumption_unit_for, parse_charge_schedule, parse_climate_schedule, parse_ev_status
 from .auth import DeviceKey, HondaAuth, encrypt_request
 from .storage import SecretStorage, get_storage
 from .translations import TRANSLATIONS, get_translator
@@ -21,6 +21,7 @@ __all__ = [
     "HondaAPIError",
     "HondaAuthError",
     "compute_trip_stats",
+    "consumption_unit_for",
     "get_translator",
     "parse_charge_schedule",
     "parse_climate_schedule",

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -134,14 +134,30 @@ def _normalize_distance_unit(raw: str, default: str = "km") -> str:
 
 
 def _normalize_speed_unit(raw: str, distance_unit: str) -> str:
-    """Normalize Honda's speed unit aliases to "<distance>/h"."""
+    """Normalize Honda's speed unit aliases to "<distance>/h".
+
+    Honda only ships per-hour speeds (km/h, mile/h), so any
+    distance-prefix variant collapses to "<canonical>/h".
+    """
     if isinstance(raw, str) and raw.strip():
-        head, _, tail = raw.strip().partition("/")
+        head = raw.strip().split("/", 1)[0]
         unit = _normalize_distance_unit(head, default="")
         if unit:
-            suffix = tail.strip().lower() or "h"
-            return f"{unit}/{suffix}"
+            return f"{unit}/h"
     return f"{distance_unit}/h"
+
+
+def consumption_unit_for(fuel_type: str, distance_unit: str) -> str:
+    """Return the canonical consumption unit for a vehicle.
+
+    Honda reports per-trip consumption in whatever unit matches the
+    account's locale: L/100km or kWh/100km for metric, mpg or mi/kWh
+    for imperial. The CLI and library agree on a single mapping here.
+    """
+    is_imperial = _normalize_distance_unit(distance_unit) == "miles"
+    if fuel_type == "E":
+        return "mi/kWh" if is_imperial else "kWh/100km"
+    return "mpg" if is_imperial else "L/100km"
 
 
 def _normalize_charge_status(raw) -> str:
@@ -1643,12 +1659,29 @@ def compute_trip_stats(rows: list[dict], period: str = "month",
         Dict with aggregated stats.
     """
     count = len(rows)
+    distance_unit = _normalize_distance_unit(distance_unit)
+    is_imperial = distance_unit == "miles"
     total_km = sum(_safe_float(r.get("Mileage")) for r in rows)
     total_min = sum(_safe_float(r.get("DriveTime")) for r in rows)
     avg_speed = sum(_safe_float(r.get("AveSpeed")) for r in rows) / count if count else 0
     max_speed = max((_safe_float(r.get("MaxSpeed")) for r in rows), default=0)
 
-    if total_km > 0:
+    if is_imperial:
+        # AveFuelEconomy is distance-per-fuel (mpg, mi/kWh): the correct
+        # rollup is total_distance / sum(distance / efficiency), not a
+        # distance-weighted average of the per-trip ratios.
+        fuel_used = 0.0
+        distance_counted = 0.0
+        for r in rows:
+            eff = _safe_float(r.get("AveFuelEconomy"))
+            dist = _safe_float(r.get("Mileage"))
+            if eff > 0:
+                fuel_used += dist / eff
+                distance_counted += dist
+        avg_consumption = distance_counted / fuel_used if fuel_used > 0 else 0.0
+    elif total_km > 0:
+        # AveFuelEconomy is fuel-per-distance (L/100km, kWh/100km):
+        # distance-weighted average gives the correct overall rate.
         avg_consumption = sum(
             _safe_float(r.get("AveFuelEconomy")) * _safe_float(r.get("Mileage"))
             for r in rows
@@ -1657,13 +1690,8 @@ def compute_trip_stats(rows: list[dict], period: str = "month",
         avg_consumption = 0.0
 
     actual_dates = sorted(set(r.get("OneTripDate", "")[:10] for r in rows))
-    distance_unit = _normalize_distance_unit(distance_unit)
     speed_unit = f"{distance_unit}/h"
-    is_imperial = distance_unit == "miles"
-    if fuel_type == "E":
-        consumption_unit = "mi/kWh" if is_imperial else "kWh/100km"
-    else:
-        consumption_unit = "mpg" if is_imperial else "L/100km"
+    consumption_unit = consumption_unit_for(fuel_type, distance_unit)
     return {
         "period": period,
         "start_date": actual_dates[0] if actual_dates else "",

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -109,6 +109,41 @@ _CHARGE_STATUS_MAP = {
 }
 
 
+_DISTANCE_UNIT_MAP = {
+    "km": "km",
+    "kms": "km",
+    "kilometer": "km",
+    "kilometers": "km",
+    "kilometre": "km",
+    "kilometres": "km",
+    "mi": "miles",
+    "mile": "miles",
+    "miles": "miles",
+}
+
+
+def _normalize_distance_unit(raw: str, default: str = "km") -> str:
+    """Normalize Honda's distance unit aliases to a canonical form.
+
+    Honda returns "mile" (singular) for UK accounts; we canonicalize to
+    "miles" so downstream consumers can pick a single shape.
+    """
+    if not isinstance(raw, str):
+        return default
+    return _DISTANCE_UNIT_MAP.get(raw.strip().lower(), default)
+
+
+def _normalize_speed_unit(raw: str, distance_unit: str) -> str:
+    """Normalize Honda's speed unit aliases to "<distance>/h"."""
+    if isinstance(raw, str) and raw.strip():
+        head, _, tail = raw.strip().partition("/")
+        unit = _normalize_distance_unit(head, default="")
+        if unit:
+            suffix = tail.strip().lower() or "h"
+            return f"{unit}/{suffix}"
+    return f"{distance_unit}/h"
+
+
 def _normalize_charge_status(raw) -> str:
     """Normalize a raw chargeStatus API value to a canonical enum value."""
     if not isinstance(raw, str):
@@ -1487,8 +1522,10 @@ def parse_ev_status(dashboard: dict) -> EVStatus:
     ev = dashboard.get("evStatus", {})
     gps = dashboard.get("gpsData", {})
     coord = gps.get("coordinate", {})
-    distance_unit = ev.get("rangeUnit", dashboard.get("odometer", {}).get("unit", "km"))
-    speed_unit = gps.get("velocity", {}).get("unit", f"{distance_unit}/h")
+    distance_unit = _normalize_distance_unit(
+        ev.get("rangeUnit", dashboard.get("odometer", {}).get("unit", "km")))
+    speed_unit = _normalize_speed_unit(
+        gps.get("velocity", {}).get("unit"), distance_unit)
     temp_unit = dashboard.get("temperature", {}).get("cabin", {}).get("unit", "c")
 
     return EVStatus(
@@ -1620,7 +1657,13 @@ def compute_trip_stats(rows: list[dict], period: str = "month",
         avg_consumption = 0.0
 
     actual_dates = sorted(set(r.get("OneTripDate", "")[:10] for r in rows))
+    distance_unit = _normalize_distance_unit(distance_unit)
     speed_unit = f"{distance_unit}/h"
+    is_imperial = distance_unit == "miles"
+    if fuel_type == "E":
+        consumption_unit = "mi/kWh" if is_imperial else "kWh/100km"
+    else:
+        consumption_unit = "mpg" if is_imperial else "L/100km"
     return {
         "period": period,
         "start_date": actual_dates[0] if actual_dates else "",
@@ -1635,5 +1678,5 @@ def compute_trip_stats(rows: list[dict], period: str = "month",
         "avg_consumption": round(avg_consumption, 1),
         "distance_unit": distance_unit,
         "speed_unit": speed_unit,
-        "consumption_unit": "kWh/100km" if fuel_type == "E" else "L/100km",
+        "consumption_unit": consumption_unit,
     }

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -26,6 +26,7 @@ from .api import (
     HondaAPIError,
     HondaAuthError,
     compute_trip_stats,
+    consumption_unit_for,
     parse_ev_status,
 )
 from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth
@@ -176,10 +177,9 @@ def _resolve_vehicle(api: HondaAPI, vin_arg: str | None) -> tuple[str | None, in
     return api.tokens.resolve_vin(vin_arg) or vin_arg, 0
 
 
-def _get_vehicle_display_context(api: HondaAPI, vin: str, args: argparse.Namespace) -> tuple[dict | None, str]:
-    """Return vehicle info and consumption unit, and print the current header when needed."""
+def _get_vehicle_display_context(api: HondaAPI, vin: str, args: argparse.Namespace) -> dict | None:
+    """Return vehicle info and print the current header when needed."""
     vehicle_info = next((vehicle for vehicle in api.tokens.vehicles if vehicle["vin"] == vin), None)
-    consumption_unit = "kWh/100km" if (vehicle_info or {}).get("fuel_type") == "E" else "L/100km"
     if not args.json and not getattr(args, "csv", False):
         if vehicle_info:
             label = vehicle_info["name"] or vin
@@ -188,7 +188,24 @@ def _get_vehicle_display_context(api: HondaAPI, vin: str, args: argparse.Namespa
         else:
             print(f"[{vin}]", file=sys.stderr)
         print(file=sys.stderr)
-    return vehicle_info, consumption_unit
+    return vehicle_info
+
+
+def _resolve_trip_units(
+    api: HondaAPI, vin: str, vehicle_info: dict | None,
+) -> tuple[str, str]:
+    """Read the vehicle's distance_unit (from the cached dashboard) and
+    derive the matching consumption_unit. Used by trips / trip-stats so
+    that imperial-locale accounts (UK) get mi / mph / mpg / mi/kWh
+    labels instead of the metric defaults."""
+    distance_unit = "km"
+    try:
+        ev = parse_ev_status(api.get_dashboard_cached(vin))
+        distance_unit = ev.get("distance_unit", "km")
+    except HondaAPIError:
+        pass
+    fuel_type = (vehicle_info or {}).get("fuel_type", "")
+    return distance_unit, consumption_unit_for(fuel_type, distance_unit)
 
 
 def _wait_command(api: HondaAPI, timeout: int, cmd_id: str, label: str) -> int:
@@ -716,7 +733,10 @@ def _load_trip_stats_rows(
     return rows, 0
 
 
-def _handle_trip_stats_command(api: HondaAPI, vin: str, args: argparse.Namespace, vehicle_info: dict | None) -> int:
+def _handle_trip_stats_command(
+    api: HondaAPI, vin: str, args: argparse.Namespace,
+    vehicle_info: dict | None, distance_unit: str,
+) -> int:
     """Handle the trip-stats command, preserving current CLI behavior."""
     ref = date.fromisoformat(args.ref_date) if args.ref_date else date.today()
     start_date, end_date = _trip_stats_period_bounds(ref, args.period)
@@ -729,7 +749,8 @@ def _handle_trip_stats_command(api: HondaAPI, vin: str, args: argparse.Namespace
         return 0
 
     fuel_type = (vehicle_info or {}).get("fuel_type", "")
-    stats = compute_trip_stats(rows, args.period, fuel_type=fuel_type)
+    stats = compute_trip_stats(
+        rows, args.period, fuel_type=fuel_type, distance_unit=distance_unit)
     if args.json:
         print(json.dumps(stats, indent=2))
     elif args.csv:
@@ -1271,7 +1292,7 @@ def _run_main(args: argparse.Namespace, storage) -> int:
             return 1
         return 0
 
-    vehicle_info, consumption_unit = _get_vehicle_display_context(api, vin, args)
+    vehicle_info = _get_vehicle_display_context(api, vin, args)
 
     confirm_exit = _confirm_command(args)
     if confirm_exit is not None:
@@ -1336,13 +1357,16 @@ def _run_main(args: argparse.Namespace, storage) -> int:
         return _handle_climate_schedule_clear_command(api, vin, args, vehicle_info)
 
     elif args.command == "trips":
+        _, consumption_unit = _resolve_trip_units(api, vin, vehicle_info)
         return _handle_trips_command(api, vin, args, vehicle_info, consumption_unit)
 
     elif args.command == "trip-detail":
         return _handle_trip_detail_command(api, vin, args)
 
     elif args.command == "trip-stats":
-        return _handle_trip_stats_command(api, vin, args, vehicle_info)
+        distance_unit, _ = _resolve_trip_units(api, vin, vehicle_info)
+        return _handle_trip_stats_command(
+            api, vin, args, vehicle_info, distance_unit)
 
     return 0
 

--- a/tests/test_cli_trip_stats.py
+++ b/tests/test_cli_trip_stats.py
@@ -14,10 +14,29 @@ class _FakeTokens:
         return value
 
 
+def _minimal_dashboard(distance_unit: str = "km") -> dict:
+    """Build the smallest dashboard payload parse_ev_status accepts."""
+    return {
+        "evStatus": {"rangeUnit": distance_unit},
+        "gpsData": {"velocity": {"unit": f"{distance_unit}/h"},
+                    "coordinate": {}},
+        "odometer": {"value": "0", "unit": distance_unit},
+        "temperature": {"cabin": {"value": "0", "unit": "c"}},
+        "doorStatus": {}, "windowStatus": {}, "lightStatus": {},
+        "warningLamps": {"messages": []},
+        "climateControl": {"status": {"isActive": False}},
+        "timestamp": "",
+    }
+
+
 class _FakeAPI:
-    def __init__(self):
+    def __init__(self, distance_unit: str = "km"):
         self.tokens = _FakeTokens()
         self.requested_months = []
+        self._distance_unit = distance_unit
+
+    def get_dashboard_cached(self, vin: str, language: str = "it") -> dict:
+        return _minimal_dashboard(self._distance_unit)
 
     def get_all_trips(self, vin: str, month_start: str = ""):
         self.requested_months.append(month_start)
@@ -66,3 +85,22 @@ def test_trip_stats_week_fetches_all_months_in_range(monkeypatch, capsys):
     assert '"trips": 2' in out.out
     assert '"start_date": "2026-03-30"' in out.out
     assert '"end_date": "2026-04-01"' in out.out
+
+
+def test_trip_stats_picks_imperial_labels_from_dashboard(monkeypatch, capsys):
+    """UK accounts (Honda returns rangeUnit='mile') must label trip-stats in miles + mi/kWh."""
+    fake_api = _FakeAPI(distance_unit="mile")
+
+    monkeypatch.setattr(importlib.metadata, "version", lambda _: "0.0")
+    monkeypatch.setattr(cli, "get_storage", lambda *args, **kwargs: object())
+    monkeypatch.setattr(cli, "HondaAPI", lambda storage=None, request_timeout=None: fake_api)
+    monkeypatch.setattr(
+        cli.sys, "argv",
+        ["pymyhondaplus", "--json", "trip-stats", "--period", "week", "--date", "2026-04-01"],
+    )
+
+    assert cli.main() == 0
+    out = capsys.readouterr().out
+    assert '"distance_unit": "miles"' in out
+    assert '"speed_unit": "miles/h"' in out
+    assert '"consumption_unit": "mi/kWh"' in out

--- a/tests/test_parse_ev_status.py
+++ b/tests/test_parse_ev_status.py
@@ -35,6 +35,32 @@ def test_gps(dashboard_ev):
     assert ev["distance_unit"] == "km"
 
 
+def test_units_uk_aliases(dashboard_ev):
+    """Honda returns 'mile' / 'mile/h' for UK accounts; canonicalize to miles."""
+    dashboard_ev["evStatus"]["rangeUnit"] = "mile"
+    dashboard_ev["odometer"]["unit"] = "mile"
+    dashboard_ev["gpsData"]["velocity"]["unit"] = "mile/h"
+    ev = parse_ev_status(dashboard_ev)
+    assert ev["distance_unit"] == "miles"
+    assert ev["speed_unit"] == "miles/h"
+
+
+def test_units_distance_alias_falls_through_to_odometer(dashboard_ev):
+    """If rangeUnit is absent we read odometer.unit, normalized."""
+    dashboard_ev["evStatus"].pop("rangeUnit", None)
+    dashboard_ev["odometer"]["unit"] = "Miles"
+    ev = parse_ev_status(dashboard_ev)
+    assert ev["distance_unit"] == "miles"
+
+
+def test_units_unknown_distance_defaults_to_km(dashboard_ev):
+    dashboard_ev["evStatus"]["rangeUnit"] = "furlong"
+    dashboard_ev["odometer"]["unit"] = "furlong"
+    ev = parse_ev_status(dashboard_ev)
+    assert ev["distance_unit"] == "km"
+    assert ev["speed_unit"] == "km/h"
+
+
 def test_doors_locked(dashboard_ev):
     ev = parse_ev_status(dashboard_ev)
     assert ev["doors_locked"] is True

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -51,6 +51,23 @@ def test_distance_unit(trip_rows):
     assert stats["speed_unit"] == "miles/h"
 
 
+def test_distance_unit_alias_normalized(trip_rows):
+    """Honda's 'mile' (singular) alias must canonicalize to 'miles'."""
+    stats = compute_trip_stats(trip_rows, distance_unit="mile")
+    assert stats["distance_unit"] == "miles"
+    assert stats["speed_unit"] == "miles/h"
+
+
+def test_consumption_unit_ice_imperial(trip_rows):
+    stats = compute_trip_stats(trip_rows, fuel_type="G", distance_unit="miles")
+    assert stats["consumption_unit"] == "mpg"
+
+
+def test_consumption_unit_ev_imperial(trip_rows):
+    stats = compute_trip_stats(trip_rows, fuel_type="E", distance_unit="miles")
+    assert stats["consumption_unit"] == "mi/kWh"
+
+
 def test_empty_rows():
     stats = compute_trip_stats([])
     assert stats["trips"] == 0

--- a/tests/test_trip_stats.py
+++ b/tests/test_trip_stats.py
@@ -68,6 +68,43 @@ def test_consumption_unit_ev_imperial(trip_rows):
     assert stats["consumption_unit"] == "mi/kWh"
 
 
+def test_avg_consumption_imperial_ice_uses_harmonic_aggregation():
+    """mpg is distance-per-fuel: 10mi @10mpg + 20mi @20mpg should be 15 mpg, not 16.7."""
+    rows = [
+        {"OneTripDate": "2026-05-01", "Mileage": "10", "AveSpeed": "30",
+         "MaxSpeed": "60", "DriveTime": "20", "AveFuelEconomy": "10"},
+        {"OneTripDate": "2026-05-02", "Mileage": "20", "AveSpeed": "40",
+         "MaxSpeed": "60", "DriveTime": "30", "AveFuelEconomy": "20"},
+    ]
+    stats = compute_trip_stats(rows, fuel_type="G", distance_unit="miles")
+    assert stats["consumption_unit"] == "mpg"
+    assert stats["avg_consumption"] == 15.0
+
+
+def test_avg_consumption_imperial_ev_uses_harmonic_aggregation():
+    """mi/kWh: 10mi @5mi/kWh + 20mi @10mi/kWh consumes 2+2=4 kWh -> 30/4 = 7.5 mi/kWh."""
+    rows = [
+        {"OneTripDate": "2026-05-01", "Mileage": "10", "AveSpeed": "30",
+         "MaxSpeed": "60", "DriveTime": "20", "AveFuelEconomy": "5"},
+        {"OneTripDate": "2026-05-02", "Mileage": "20", "AveSpeed": "40",
+         "MaxSpeed": "60", "DriveTime": "30", "AveFuelEconomy": "10"},
+    ]
+    stats = compute_trip_stats(rows, fuel_type="E", distance_unit="miles")
+    assert stats["consumption_unit"] == "mi/kWh"
+    assert stats["avg_consumption"] == 7.5
+
+
+def test_avg_consumption_imperial_skips_zero_efficiency_rows():
+    rows = [
+        {"OneTripDate": "2026-05-01", "Mileage": "10", "AveSpeed": "30",
+         "MaxSpeed": "60", "DriveTime": "20", "AveFuelEconomy": "10"},
+        {"OneTripDate": "2026-05-02", "Mileage": "5", "AveSpeed": "0",
+         "MaxSpeed": "0", "DriveTime": "5", "AveFuelEconomy": "0"},
+    ]
+    stats = compute_trip_stats(rows, fuel_type="G", distance_unit="miles")
+    assert stats["avg_consumption"] == 10.0
+
+
 def test_empty_rows():
     stats = compute_trip_stats([])
     assert stats["trips"] == 0


### PR DESCRIPTION
For UK accounts Honda returns `rangeUnit: "mile"` (singular) and `speed_unit: "mile/h"`, and ships consumption in mpg / mi/kWh regardless of `fuel_type`. The library was passing the aliases through unchanged, and `compute_trip_stats` hard-coded `consumption_unit` to `L/100km` or `kWh/100km`.

## Changes

- `parse_ev_status` canonicalizes `distance_unit` (`mile`/`miles`/`mi` → `miles`, `kilometer*` → `km`, case-insensitive); `speed_unit` follows the same shape.
- `compute_trip_stats` normalizes its `distance_unit` argument and picks `consumption_unit` from the `(fuel_type, distance_unit)` matrix: `mpg` for ICE+miles, `mi/kWh` for EV+miles, `L/100km` and `kWh/100km` unchanged.

Diagnostics from two UK reporters confirm both aliases and the mislabelled consumption.

## Tests

- `test_parse_ev_status.py`: 3 new cases (UK aliases, fallback to `odometer.unit`, unknown unit defaults to km).
- `test_trip_stats.py`: 3 new cases (singular `mile` alias, ICE+imperial → `mpg`, EV+imperial → `mi/kWh`).

Refs enricobattocchi/myhondaplus-homeassistant#47
