### PR TITLE
fix: normalize speed_unit in CarLocation.from_command_result

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,13 @@
 
 All notable changes to this project will be documented in this file.
 
+## 5.10.1 (2026-05-30)
+
+### Fixed
+
+- `CarLocation.from_command_result` canonicalizes `velocity.unit` through `_normalize_speed_unit`. Previously only `"kph"` was rewritten to `"km/h"`, so UK accounts (Honda returns `"mile/h"`) surfaced the raw alias through `pymyhondaplus find-car` and the Home Assistant `car_finder_location` service, while the rest of the stack had already settled on `"miles/h"`.
+- `_normalize_speed_unit` learns the slash-less aliases `kph` / `kmh` / `kmph` / `mph` that the car-location endpoint can return.
+
 ## 5.10.0 (2026-05-30)
 
 ### Added

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "pymyhondaplus"
-version = "5.10.0"
+version = "5.10.1"
 description = "Unofficial Python client for the Honda Connect Europe (My Honda+) API"
 readme = "README.md"
 license = "MIT"

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -133,14 +133,27 @@ def _normalize_distance_unit(raw: str, default: str = "km") -> str:
     return _DISTANCE_UNIT_MAP.get(raw.strip().lower(), default)
 
 
+_SPEED_UNIT_ALIASES = {
+    "kph": "km/h",
+    "kmh": "km/h",
+    "kmph": "km/h",
+    "mph": "miles/h",
+}
+
+
 def _normalize_speed_unit(raw: str, distance_unit: str) -> str:
     """Normalize Honda's speed unit aliases to "<distance>/h".
 
-    Honda only ships per-hour speeds (km/h, mile/h), so any
-    distance-prefix variant collapses to "<canonical>/h".
+    Honda only ships per-hour speeds. The dashboard uses "km/h" or
+    "mile/h"; the car-location endpoint uses "kph"; locale-specific
+    aliases like "mph" / "kmh" / "mi/h" may also surface. Everything
+    collapses to a canonical "<distance>/h".
     """
     if isinstance(raw, str) and raw.strip():
-        head = raw.strip().split("/", 1)[0]
+        normalized = raw.strip().lower()
+        if normalized in _SPEED_UNIT_ALIASES:
+            return _SPEED_UNIT_ALIASES[normalized]
+        head = normalized.split("/", 1)[0]
         unit = _normalize_distance_unit(head, default="")
         if unit:
             return f"{unit}/h"
@@ -300,7 +313,7 @@ class CarLocation:
         coord = gps.get("coordinate") or {}
         velocity = gps.get("velocity") or {}
         # Coordinates from this endpoint come as integer milliarcseconds.
-        unit_raw = velocity.get("unit", "kph")
+        speed_unit = _normalize_speed_unit(velocity.get("unit", "kph"), "km")
         # Normalize ignition: API returns "ignitionOn" / "ignitionOff" here,
         # but the dashboard's igStatus field uses "ON" / "OFF". Collapse to a
         # canonical lowercase "on" / "off" so downstream display logic can
@@ -319,7 +332,7 @@ class CarLocation:
             longitude=float(coord.get("longitude", 0)) / 3_600_000,
             timestamp=gps.get("dtTime", ""),
             speed=float(velocity.get("value", 0)),
-            speed_unit="km/h" if unit_raw == "kph" else unit_raw,
+            speed_unit=speed_unit,
             course_heading=float(gps.get("courseHeading", 0)),
             ignition=ignition,
         )

--- a/tests/test_car_location.py
+++ b/tests/test_car_location.py
@@ -86,3 +86,47 @@ def test_handles_pre_parsed_content():
     assert loc is not None
     assert loc.speed == 5.0
     assert loc.ignition == "on"
+
+
+def test_speed_unit_uk_alias_normalized():
+    """UK accounts come back with 'mile/h'; canonicalize to 'miles/h'."""
+    result = _make_result({
+        "gpsData": {
+            "dtTime": "2026-04-26T18:18:01+00:00",
+            "coordinate": {"latitude": 0, "longitude": 0},
+            "velocity": {"unit": "mile/h", "value": 22.0},
+        },
+        "ignition": "ignitionOff",
+    })
+    loc = CarLocation.from_command_result(result)
+    assert loc is not None
+    assert loc.speed == 22.0
+    assert loc.speed_unit == "miles/h"
+
+
+def test_speed_unit_mph_alias_normalized():
+    """Also collapse the bare 'mph' alias to 'miles/h'."""
+    result = _make_result({
+        "gpsData": {
+            "coordinate": {"latitude": 0, "longitude": 0},
+            "velocity": {"unit": "mph", "value": 30.0},
+        },
+        "ignition": "ignitionOff",
+    })
+    loc = CarLocation.from_command_result(result)
+    assert loc is not None
+    assert loc.speed_unit == "miles/h"
+
+
+def test_speed_unit_unknown_defaults_to_km_h():
+    """An unrecognized unit string falls back to 'km/h' (EU default)."""
+    result = _make_result({
+        "gpsData": {
+            "coordinate": {"latitude": 0, "longitude": 0},
+            "velocity": {"unit": "furlongs/fortnight", "value": 0},
+        },
+        "ignition": "ignitionOff",
+    })
+    loc = CarLocation.from_command_result(result)
+    assert loc is not None
+    assert loc.speed_unit == "km/h"


### PR DESCRIPTION
`parse_ev_status` canonicalizes Honda's UK speed alias (`mile/h` → `miles/h`) via `_normalize_speed_unit`, but `CarLocation.from_command_result` still passed `velocity.unit` through with only a `"kph"` → `"km/h"` swap. The HA integration's `car_finder_location` service surfaces `speed_unit` to user automations directly, so UK users would see `"mile/h"` while the rest of the stack reports `"miles/h"`.

Audit-trail gap from #19, not caught at the time because the Car Finder path doesn't drive any HA sensor entity, only the service response payload.

## Changes

- `CarLocation.from_command_result` now calls `_normalize_speed_unit(velocity.unit, "km")`.
- `_normalize_speed_unit` gains a small alias table for slash-less variants (`kph`, `kmh`, `kmph`, `mph`) that the dashboard parser never sees but the car-location endpoint does.

## Tests

- `test_speed_unit_uk_alias_normalized`: Honda's `"mile/h"` → `"miles/h"`.
- `test_speed_unit_mph_alias_normalized`: bare `"mph"` → `"miles/h"`.
- `test_speed_unit_unknown_defaults_to_km_h`: unrecognized unit falls back to `"km/h"`.

Refs enricobattocchi/myhondaplus-homeassistant#47
