### PR TITLE
ci: pin the ruff rule set and clear the resulting lint

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,7 @@ dependencies = [
 [project.optional-dependencies]
 keyring = ["keyring>=24.0"]
 completion = ["argcomplete>=3.0"]
-dev = ["pytest>=7.0", "ruff>=0.4", "mypy>=1.10", "types-requests>=2.31"]
+dev = ["pytest>=7.0", "ruff>=0.16.1,<0.17", "mypy>=1.10", "types-requests>=2.31"]
 
 [project.urls]
 Homepage = "https://github.com/enricobattocchi/pymyhondaplus"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -42,6 +42,17 @@ pymyhondaplus = "pymyhondaplus.cli:_main"
 [tool.pytest.ini_options]
 testpaths = ["tests"]
 
+[tool.ruff]
+target-version = "py311"
+line-length = 100
+
+[tool.ruff.lint]
+select = ["E", "F", "W", "I", "UP", "B"]
+ignore = ["E501"]
+
+[tool.ruff.lint.isort]
+known-first-party = ["pymyhondaplus"]
+
 [tool.mypy]
 ignore_missing_imports = true
 

--- a/src/pymyhondaplus/__init__.py
+++ b/src/pymyhondaplus/__init__.py
@@ -1,6 +1,25 @@
 """Unofficial Honda Connect Europe (My Honda+) API client library."""
 
-from .api import AuthTokens, CommandResult, EVStatus, Geofence, HondaAPI, HondaAPIError, HondaAuthError, SubscriptionService, Subscription, UIConfiguration, UserProfile, Vehicle, VehicleCapabilities, compute_trip_stats, consumption_unit_for, parse_charge_schedule, parse_climate_schedule, parse_ev_status
+from .api import (
+    AuthTokens,
+    CommandResult,
+    EVStatus,
+    Geofence,
+    HondaAPI,
+    HondaAPIError,
+    HondaAuthError,
+    Subscription,
+    SubscriptionService,
+    UIConfiguration,
+    UserProfile,
+    Vehicle,
+    VehicleCapabilities,
+    compute_trip_stats,
+    consumption_unit_for,
+    parse_charge_schedule,
+    parse_climate_schedule,
+    parse_ev_status,
+)
 from .auth import DeviceKey, HondaAuth, encrypt_request
 from .storage import SecretStorage, get_storage
 from .translations import TRANSLATIONS, get_translator

--- a/src/pymyhondaplus/api.py
+++ b/src/pymyhondaplus/api.py
@@ -6,13 +6,14 @@ Tested on Honda e. Should work with other Honda Connect Europe vehicles
 """
 
 import json
-import os
-import time
 import logging
+import os
 import threading
-from pathlib import Path
+import time
 from dataclasses import dataclass, field
-from typing import Optional, TYPE_CHECKING
+from datetime import UTC
+from pathlib import Path
+from typing import TYPE_CHECKING, Optional
 
 import requests
 from urllib3.util.retry import Retry
@@ -703,7 +704,7 @@ class Vehicle:
         try:
             return getattr(self, key)
         except AttributeError:
-            raise KeyError(key)
+            raise KeyError(key) from None
 
     def get(self, key: str, default=None):
         return getattr(self, key, default)
@@ -819,7 +820,7 @@ class HondaAPI:
     """
 
     def __init__(self, storage: Optional["SecretStorage"] = None,
-                 token_file: Optional[Path] = None,
+                 token_file: Path | None = None,
                  request_timeout: float = DEFAULT_REQUEST_TIMEOUT):
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)
@@ -843,8 +844,8 @@ class HondaAPI:
 
         # Backward compatibility: token_file without storage
         if storage is None and token_file is not None:
-            from .storage import PlainFileStorage
             from .auth import DEFAULT_DEVICE_KEY_FILE
+            from .storage import PlainFileStorage
             self._storage = PlainFileStorage(token_file, DEFAULT_DEVICE_KEY_FILE)
 
         if self._storage is not None:
@@ -1398,8 +1399,8 @@ class HondaAPI:
             page: Page number (1-based)
         """
         if not month_start:
-            from datetime import datetime, timezone
-            now = datetime.now(timezone.utc)
+            from datetime import datetime
+            now = datetime.now(UTC)
             month_start = now.replace(day=1, hour=0, minute=0, second=0, microsecond=0).strftime(
                 "%Y-%m-%dT%H:%M:%S.000Z")
         import urllib.parse
@@ -1461,7 +1462,7 @@ class HondaAPI:
             if page >= data.get("maxPage", 1):
                 break
             page += 1
-        rows = [dict(zip(fields, trip)) for trip in all_trips]
+        rows = [dict(zip(fields, trip, strict=False)) for trip in all_trips]
 
         if ref_date:
             rows = [r for r in rows if r.get("OneTripDate", "").startswith(ref_date[:10])]
@@ -1484,7 +1485,7 @@ class HondaAPI:
             detail = self.get_trip_detail(vin, start_time, end_time, trip_type)
             data = detail.get("payload", {}).get("data", [[]])[0]
             fields = detail.get("payload", {}).get("def", [])
-            row = dict(zip(fields, data))
+            row = dict(zip(fields, data, strict=False))
             result[f"{prefix}_lat"] = row.get("lat")
             result[f"{prefix}_lon"] = row.get("lon")
             result[f"{prefix}_dir"] = row.get("dir")
@@ -1537,7 +1538,7 @@ class EVStatus:
         try:
             return getattr(self, key)
         except AttributeError:
-            raise KeyError(key)
+            raise KeyError(key) from None
 
     def get(self, key: str, default=None):
         return getattr(self, key, default)

--- a/src/pymyhondaplus/auth.py
+++ b/src/pymyhondaplus/auth.py
@@ -10,15 +10,14 @@ import logging
 import os
 import urllib.parse
 from pathlib import Path
-from typing import Optional
 
 import requests
-
-from .api import HondaAuthError
-from .http import DEFAULT_AUTH_TIMEOUT, TimeoutAdapter
 from cryptography.hazmat.primitives import hashes, serialization
 from cryptography.hazmat.primitives.asymmetric import padding, rsa
 from cryptography.hazmat.primitives.ciphers import Cipher, algorithms, modes
+
+from .api import HondaAuthError
+from .http import DEFAULT_AUTH_TIMEOUT, TimeoutAdapter
 
 logger = logging.getLogger(__name__)
 
@@ -126,8 +125,8 @@ class DeviceKey:
 
     _private_key: rsa.RSAPrivateKey
 
-    def __init__(self, pem_data: Optional[bytes] = None,
-                 key_file: Optional[Path] = None,
+    def __init__(self, pem_data: bytes | None = None,
+                 key_file: Path | None = None,
                  storage=None):
         self._key_file = key_file
         self._storage = storage
@@ -206,7 +205,7 @@ class DeviceKey:
 class HondaAuth:
     """Handles the full Honda Connect Europe authentication flow."""
 
-    def __init__(self, device_key: Optional[DeviceKey] = None,
+    def __init__(self, device_key: DeviceKey | None = None,
                  request_timeout: float = DEFAULT_AUTH_TIMEOUT):
         self.session = requests.Session()
         self.session.headers.update(DEFAULT_HEADERS)

--- a/src/pymyhondaplus/cli.py
+++ b/src/pymyhondaplus/cli.py
@@ -11,7 +11,7 @@ import os
 import sys
 import threading
 import time
-from datetime import date, datetime, timedelta, timezone
+from datetime import UTC, date, datetime, timedelta
 from pathlib import Path
 
 try:
@@ -33,8 +33,13 @@ from .auth import DEFAULT_DEVICE_KEY_FILE, DeviceKey, HondaAuth
 from .http import DEFAULT_REQUEST_TIMEOUT
 from .storage import get_storage
 from .translations import (
-    CHARGE_MODE_FALLBACK_MAP, CHARGE_MODE_MAP, CHARGE_STATUS_MAP,
-    IG_STATUS_MAP, PLUG_STATUS_MAP, TEMP_UNIT_MAP, get_translator,
+    CHARGE_MODE_FALLBACK_MAP,
+    CHARGE_MODE_MAP,
+    CHARGE_STATUS_MAP,
+    IG_STATUS_MAP,
+    PLUG_STATUS_MAP,
+    TEMP_UNIT_MAP,
+    get_translator,
 )
 
 WATCH_FIELDS = {
@@ -139,7 +144,7 @@ def _to_utc_iso(s: str) -> str:
     Returns the input unchanged if it can't be parsed; the API will then surface its own error.
     """
     try:
-        return datetime.fromisoformat(s).astimezone(timezone.utc).strftime("%Y-%m-%dT%H:%M:%S+00:00")
+        return datetime.fromisoformat(s).astimezone(UTC).strftime("%Y-%m-%dT%H:%M:%S+00:00")
     except (ValueError, TypeError):
         return s
 
@@ -622,7 +627,7 @@ def _load_trip_rows(api: HondaAPI, vin: str, args: argparse.Namespace, vehicle_i
             return None, 0
         payload = data.get("payload", {})
         fields = payload.get("def", [])
-        rows = [dict(zip(fields, trip)) for trip in payload.get("data", [])]
+        rows = [dict(zip(fields, trip, strict=False)) for trip in payload.get("data", [])]
         if not args.json and not args.csv:
             print(f"Page {data.get('page', '?')}/{data.get('maxPage', '?')}")
         return rows, 0

--- a/src/pymyhondaplus/storage.py
+++ b/src/pymyhondaplus/storage.py
@@ -11,8 +11,8 @@ from abc import ABC, abstractmethod
 from pathlib import Path
 
 from cryptography.fernet import Fernet, InvalidToken
-from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 from cryptography.hazmat.primitives import hashes
+from cryptography.hazmat.primitives.kdf.pbkdf2 import PBKDF2HMAC
 
 logger = logging.getLogger(__name__)
 

--- a/tests/test_api_client.py
+++ b/tests/test_api_client.py
@@ -1,12 +1,12 @@
 """Tests for HondaAPI HTTP layer — auth headers, token refresh, error handling."""
 
-from unittest.mock import MagicMock
 import time
+from unittest.mock import MagicMock
 
 import pytest
 import requests
 
-from pymyhondaplus.api import HondaAPI, HondaAPIError, HondaAuthError, AuthTokens
+from pymyhondaplus.api import AuthTokens, HondaAPI, HondaAPIError, HondaAuthError
 
 
 def _make_api(**token_overrides):
@@ -233,9 +233,11 @@ class TestTimeoutAdapter:
     """TimeoutAdapter applies default timeout to all requests."""
 
     def test_applies_default_timeout(self):
-        from pymyhondaplus.http import DEFAULT_REQUEST_TIMEOUT, TimeoutAdapter
-        from requests import PreparedRequest
         from unittest.mock import patch
+
+        from requests import PreparedRequest
+
+        from pymyhondaplus.http import DEFAULT_REQUEST_TIMEOUT, TimeoutAdapter
 
         adapter = TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:
@@ -246,9 +248,11 @@ class TestTimeoutAdapter:
             assert call_kwargs["timeout"] == DEFAULT_REQUEST_TIMEOUT
 
     def test_respects_explicit_timeout(self):
-        from pymyhondaplus.http import TimeoutAdapter
-        from requests import PreparedRequest
         from unittest.mock import patch
+
+        from requests import PreparedRequest
+
+        from pymyhondaplus.http import TimeoutAdapter
 
         adapter = TimeoutAdapter()
         with patch("requests.adapters.HTTPAdapter.send") as mock_send:

--- a/tests/test_geofence.py
+++ b/tests/test_geofence.py
@@ -2,7 +2,6 @@
 
 from pymyhondaplus.api import Geofence
 
-
 # Colosseum, Rome: 41.890251°N, 12.492373°E → MAS: 150804903, 44972542
 ACTIVE_GEOFENCE_API = {
     "nickName": "Geofence",
@@ -103,6 +102,7 @@ class TestWaitForGeofence:
     def _build_api(self, responses):
         """Return a HondaAPI whose get_geofence emits the given sequence."""
         import time as _time
+
         from pymyhondaplus.api import HondaAPI
 
         api = HondaAPI.__new__(HondaAPI)

--- a/tests/test_storage.py
+++ b/tests/test_storage.py
@@ -6,9 +6,9 @@ from unittest.mock import MagicMock, patch
 import pytest
 
 from pymyhondaplus.storage import (
-    PlainFileStorage,
     EncryptedFileStorage,
     KeyringStorage,
+    PlainFileStorage,
     get_storage,
 )
 

--- a/tests/test_thread_safety.py
+++ b/tests/test_thread_safety.py
@@ -6,7 +6,7 @@ from unittest.mock import MagicMock
 
 import requests
 
-from pymyhondaplus.api import HondaAPI, AuthTokens
+from pymyhondaplus.api import AuthTokens, HondaAPI
 
 
 def _make_api(**token_overrides):

--- a/tests/test_translations.py
+++ b/tests/test_translations.py
@@ -1,8 +1,11 @@
 """Tests for the translations module."""
 
 from pymyhondaplus.translations import (
-    CHARGE_MODE_MAP, CHARGE_STATUS_MAP, PLUG_STATUS_MAP,
-    TRANSLATIONS, get_translator,
+    CHARGE_MODE_MAP,
+    CHARGE_STATUS_MAP,
+    PLUG_STATUS_MAP,
+    TRANSLATIONS,
+    get_translator,
 )
 
 

--- a/tests/test_vehicle.py
+++ b/tests/test_vehicle.py
@@ -3,10 +3,14 @@
 import time
 
 import pytest
-from pymyhondaplus.api import (
-    AuthTokens, Subscription, UserProfile, Vehicle, VehicleCapabilities,
-)
 
+from pymyhondaplus.api import (
+    AuthTokens,
+    Subscription,
+    UserProfile,
+    Vehicle,
+    VehicleCapabilities,
+)
 
 # -- Sample API data matching captured response --
 
@@ -240,11 +244,8 @@ class TestVehicleDictAccess:
 
     def test_missing_key_raises(self):
         v = Vehicle.from_api(FULL_VEHICLE_API)
-        try:
+        with pytest.raises(KeyError):
             _ = v["nonexistent"]
-            assert False, "Should have raised KeyError"
-        except KeyError:
-            pass
 
 
 class TestVehicleSerialization:


### PR DESCRIPTION
The lint job started failing without a line of code changing. This repo was the only one of the three without a ruff config, so it followed ruff's default rule selection, and ruff 0.16 widened that default. The last CI run here was in May, so this is the first time it met the new version.

Adopts the configuration `myhondaplus-desktop` and `myhondaplus-homeassistant` already use: `select = ["E", "F", "W", "I", "UP", "B"]`, `ignore = ["E501"]`, `target-version = "py311"`. That brings the 38 findings down to 27, and this clears all of them: 26 automatic fixes plus six by hand.

The six manual ones:

| Rule | Where | Change |
|---|---|---|
| B904 ×2 | `api.py` `__getitem__` | `raise KeyError(key) from None` |
| B905 ×3 | `api.py`, `cli.py` | `zip(..., strict=False)` |
| B011 ×1 | `tests/test_vehicle.py` | `pytest.raises(KeyError)`, matching the rest of the file |

**One call worth a second opinion:** `strict=False` preserves exactly today's behaviour. `strict=True` would raise when Honda returns a row whose length does not match the field list, which would break every trips fetch instead of dropping a column. Say the word if you would rather have it loud.

Verified locally: ruff 0.16.1 and 0.15.10 both clean, 271 tests pass, and mypy passes on both 1.20.0 and 2.3.0 (the version CI resolves to, checked in a separate venv so the type-check step does not become the next surprise).
