### PR TITLE
ci: pin the rest of the toolchain and let dependabot bump it

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -1,0 +1,23 @@
+version: 2
+
+updates:
+  # The toolchain is pinned to a minor line on purpose: ruff, mypy and their
+  # stubs add diagnostics in minor releases, which fails lint on code nobody
+  # touched. Dependabot is what keeps those pins from ageing in silence.
+  - package-ecosystem: "pip"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      python-toolchain:
+        patterns:
+          - "*"
+
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+    groups:
+      github-actions:
+        patterns:
+          - "*"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -28,7 +28,12 @@ dependencies = [
 [project.optional-dependencies]
 keyring = ["keyring>=24.0"]
 completion = ["argcomplete>=3.0"]
-dev = ["pytest>=7.0", "ruff>=0.16.1,<0.17", "mypy>=1.10", "types-requests>=2.31"]
+dev = [
+    "pytest>=9.0,<10",
+    "ruff>=0.16.1,<0.17",
+    "mypy>=2.3,<2.4",
+    "types-requests>=2.33,<2.34",
+]
 
 [project.urls]
 Homepage = "https://github.com/enricobattocchi/pymyhondaplus"


### PR DESCRIPTION
Finishes the job #22 started. Ruff got pinned there, but `mypy>=1.10`, `pytest>=7.0` and `types-requests>=2.31` were left wide open, and they fail on unchanged code by exactly the same mechanism.

That was not hypothetical: mypy resolved to **2.3.0** in CI while this repo's venv had **1.20.0**. The two had drifted more than a major apart and nobody knew, because the type-check step never ran once lint started failing.

| Tool | Was | Now | Why |
|---|---|---|---|
| mypy | `>=1.10` | `>=2.3,<2.4` | new checks land in minors |
| ruff | `>=0.16.1,<0.17` | unchanged | already done in #22 |
| types-requests | `>=2.31` | `>=2.33,<2.34` | new stubs surface new mypy errors |
| pytest | `>=7.0` | `>=9.0,<10` | only majors break test code |

The floor on pytest is 9.0 rather than 9.1 so existing local venvs still satisfy it. mypy is the one that will want a `pip install -e ".[dev]"` locally, which is the point: local and CI should agree.

**Dependabot.** Pinning without automation just moves the rot: `<0.17` and `<2.4` would sit there until someone remembered. Weekly grouped PRs for both `pip` and `github-actions`, each arriving with CI proof.

One caveat worth watching: I could not confirm from GitHub's docs whether Dependabot's `pip` ecosystem reads PEP 621 `[project.optional-dependencies]`. If it does not, it will say so in the repo's Dependabot tab within a day and the `pip` block can be dropped. The `github-actions` block is not in doubt, and that is the one that would have caught the Node 20 deprecation on its own.

Verified: the constraint set resolves clean, ruff 0.16.1 and mypy 2.3.0 both pass, 271 tests green.
